### PR TITLE
oslo configuration groups for api, netconf, and DEFAULT can be read --WIP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ flocx_market.egg-info/
 AUTHORS
 ChangeLog
 etc/flocx-market/flocx-market.conf.sample
+*.pyc

--- a/flocx_market/cmd/api.py
+++ b/flocx_market/cmd/api.py
@@ -1,15 +1,19 @@
 from wsgiref import simple_server
 from flocx_market.api import app
+from flocx_market.common import config as flocx_market_config
+import sys
+import flocx_market.conf
 
+CONF = flocx_market.conf.CONF
 
 def main():
-    host = '0.0.0.0'
-    port = 8080
+    flocx_market_config.prepare_service(sys.argv)
 
-    application = app.setup_app()
-    srv = simple_server.make_server(host, port, application)
-    print('Server on port 8080, listening...')
-    srv.serve_forever()
+    # Build and start the WSGI app
+    launcher = flocx_market_config.ProcessLauncher(CONF, restart_method='mutate')
+    server = wsgi_service.WSGIService('esi_leap_api')
+    launcher.launch_service(server, workers=server.workers)
+    launcher.wait()
 
 
 if __name__ == '__main__':

--- a/flocx_market/common/config.py
+++ b/flocx_market/common/config.py
@@ -1,0 +1,23 @@
+from oslo_db import options as db_options
+from oslo_log import log
+from oslo_service import service
+
+import flocx_market.conf
+# from flocx_market import objects
+
+CONF = flocx_market.conf.CONF
+
+
+def prepare_service(argv=None, default_config_files=None):
+    argv = [] if argv is None else argv
+    log.register_options(CONF)
+    CONF(argv[1:],
+         project='flocx-market',
+         default_config_files=default_config_files)
+    db_options.set_defaults(CONF)
+    log.setup(CONF, 'flocx-market')
+    # objects.register_all()
+
+
+def process_launcher():
+    return service.ProcessLauncher(CONF, restart_method='mutate')

--- a/flocx_market/tests/unit/test_auth.py
+++ b/flocx_market/tests/unit/test_auth.py
@@ -1,0 +1,14 @@
+import flocx_market.conf as conf
+from flocx_market.common import config as flocx_market_config
+import sys
+CONF = conf.CONF
+
+
+def test_keystone_default():
+    flocx_market_config.prepare_service(sys.argv)
+
+    print (CONF.api.port)
+    # print (CONF.keystone_authtoken.username)
+
+
+test_keystone_default()


### PR DESCRIPTION
The configurations in the conf folder which are added to oslo.cfg can be modified in the config file, but default groups such as kaystone_authoken cannot be read. I am trying to test this through test_auth as opposed to through cmd/api.py