### PR TITLE
Add tests for Default oslo configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ flocx_market.egg-info/
 AUTHORS
 ChangeLog
 etc/flocx-market/flocx-market.conf.sample
+*.pyc

--- a/flocx_market/tests/unit/conf/test_conf.py
+++ b/flocx_market/tests/unit/conf/test_conf.py
@@ -1,0 +1,25 @@
+import flocx_market.conf as conf
+import socket
+
+CONF = conf.CONF
+
+
+def test_api_defaults():
+
+    assert(CONF.api.host_ip == "0.0.0.0")
+    assert(CONF.api.port == 8081)
+    assert(CONF.api.max_limit == 1000)
+    assert(CONF.api.public_endpoint is None)
+    assert(CONF.api.api_workers is None)
+    assert(CONF.api.enable_ssl_api is False)
+
+
+def test_flask_defaults():
+
+    assert(CONF.flask.SQLALCHEMY_TRACK_MODIFICATIONS is False)
+    assert(CONF.flask.PROPAGATE_EXCEPTIONS is False)
+
+
+def test_netconf_defaults():
+
+    assert(CONF.host == socket.gethostname())


### PR DESCRIPTION
The default configurations created by oslo can be viewed through the CONF object. Modifications to these variables in /etc/flocx-market/flocx-market.conf can also be seen in the CONF object