### PR TITLE
Limit pep8 check to flocx_market directory

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,11 +16,11 @@ deps = -r{toxinidir}/requirements.txt
 
 [testenv:pep8]
 commands =
-        ./flakeight.sh
+        ./flakeight.sh {posargs:flocx_market}
 
 [testenv:py37]
 commands = 
-        pytest flocx_market/tests/unit/
+        pytest {posargs:flocx_market/tests/unit}
 
 
 [flake8]
@@ -35,5 +35,5 @@ commands =
 [testenv:commit]
 basepython = python3
 commands = 
-        pytest --tb=short flocx_market/tests/commit/
+        pytest --tb=short flocx_market/tests/commit/ {posargs}
 passenv = TRAVIS* COMMIT* GITHUB*


### PR DESCRIPTION
Limit the pep8 check to the flocx_market directory, to avoid
checking Python files that are not part of the repository. We also add
{posargs} to most tox checks to allow additional configuration from
the command line.

Closes #22