### PR TITLE
Hooks for default config file and business logic objects

### DIFF
--- a/flocx_market/common/service.py
+++ b/flocx_market/common/service.py
@@ -1,0 +1,26 @@
+from oslo_db import options as db_options
+from oslo_log import log
+from oslo_service import service
+
+import flocx_market.conf
+from flocx_market import objects
+from flocx_market import version
+
+CONF = flocx_market.conf.CONF
+
+
+def prepare_service(argv=None, default_config_files=None):
+    argv = [] if argv is None else argv
+    log.register_options(CONF)
+    CONF(argv[1:],
+         project='flocx-market',
+         version=version.version_info.release_string(),
+         default_config_files=default_config_files)
+
+    db_options.set_defaults(CONF)
+    log.setup(CONF, 'flocx-market')
+    objects.register_all()
+
+
+def process_launcher():
+    return service.ProcessLauncher(CONF, restart_method='mutate')

--- a/flocx_market/conf/api.py
+++ b/flocx_market/conf/api.py
@@ -21,3 +21,4 @@ api_group = cfg.OptGroup(
 
 def register_opts(conf):
     conf.register_opts(opts, group=api_group)
+    conf.register_cli_opts(opts, group=api_group)

--- a/flocx_market/conf/flask.py
+++ b/flocx_market/conf/flask.py
@@ -15,3 +15,4 @@ flask_group = cfg.OptGroup(
 
 def register_opts(conf):
     conf.register_opts(opts, group=flask_group)
+    conf.register_cli_opts(opts, group=flask_group)

--- a/flocx_market/conf/netconf.py
+++ b/flocx_market/conf/netconf.py
@@ -11,3 +11,4 @@ opts = [
 
 def register_opts(conf):
     conf.register_opts(opts)
+    conf.register_cli_opts(opts)

--- a/flocx_market/objects/__init__.py
+++ b/flocx_market/objects/__init__.py
@@ -1,0 +1,6 @@
+# put import statements for all objects in the objects directory in register_all
+# Called as a hook in common/services.py
+
+
+def register_all():
+    pass

--- a/flocx_market/tests/unit/common/test_service.py
+++ b/flocx_market/tests/unit/common/test_service.py
@@ -1,0 +1,66 @@
+import flocx_market.conf as conf
+import socket
+import flocx_market.common.service as flocx_market_service
+import pytest
+import unittest.mock as mock
+
+CONF = conf.CONF
+
+
+@mock.patch('oslo_config.cfg.find_config_files')
+def test_service_defaults(find_config_files):
+
+    CONF.clear()
+    flocx_market_service.prepare_service()
+    assert(CONF.api.host_ip == "0.0.0.0")
+    assert(CONF.api.port == 8081)
+    assert(CONF.api.max_limit == 1000)
+    assert(CONF.api.public_endpoint is None)
+    assert(CONF.api.api_workers is None)
+    assert(CONF.api.enable_ssl_api is False)
+    assert(CONF.flask.SQLALCHEMY_TRACK_MODIFICATIONS is False)
+    assert(CONF.flask.PROPAGATE_EXCEPTIONS is False)
+    assert(CONF.host == socket.gethostname())
+
+
+@mock.patch('oslo_config.cfg.find_config_files')
+def test_service_cli_valid(find_config_files):
+
+    CONF.clear()
+    args = ['dummy', '--api-port', '8085', '--api-host_ip', '0.0.0.1',
+            '--api-public_endpoint', '/index', '--api-api_workers', '5', '--api-enable_ssl',
+            '--flask-noSQLALCHEMY_TRACK_MODIFICATIONS', '--flask-PROPAGATE_EXCEPTIONS', '--host', 'imhost']
+
+    flocx_market_service.prepare_service(argv=args)
+    assert(CONF.api.port == int(args[args.index('--api-port') + 1]))
+    assert(CONF.api.host_ip == str(args[args.index('--api-host_ip') + 1]))
+    assert(CONF.api.public_endpoint == str(args[args.index('--api-public_endpoint') + 1]))
+    assert(CONF.api.api_workers == int(args[args.index('--api-api_workers') + 1]))
+    assert(CONF.api.enable_ssl_api)
+
+    assert(CONF.api.max_limit == 1000)
+
+    assert(CONF.flask.SQLALCHEMY_TRACK_MODIFICATIONS is False)
+    assert(CONF.flask.PROPAGATE_EXCEPTIONS)
+
+    assert(CONF.host == str(args[args.index('--host') + 1]))
+
+
+@mock.patch('oslo_config.cfg.find_config_files')
+def test_service_cli_invalid_option(find_config_files):
+    CONF.clear()
+    with pytest.raises(SystemExit) as excinfo:
+        flocx_market_service.prepare_service(
+            argv=['dummy', '--badarg'])
+
+    assert excinfo.value.code == 2
+
+
+@mock.patch('oslo_config.cfg.find_config_files')
+def test_service_cli_invalid_value(find_config_files):
+    CONF.clear()
+    with pytest.raises(SystemExit) as excinfo:
+        flocx_market_service.prepare_service(
+            argv=['dummy', '--api-port', 'notInt'])
+
+    assert excinfo.value.code is None

--- a/flocx_market/version.py
+++ b/flocx_market/version.py
@@ -1,0 +1,3 @@
+from pbr import version
+
+version_info = version.VersionInfo('flocx-market')


### PR DESCRIPTION
Created service.py which hooks to oslo the configuration options from
the config file located at /etc/flocx-market/flocx-market.conf to make
them accessible by the CONF object. Additionally, added the version and
objects hooks, so oslo cna be aware of the version through pbr and the
business logic objects we will eventually create in the
flocx_market/objects directory