### PR TITLE
Fix test_invalid_data_type test in test_matcher.py

### DIFF
--- a/flocx_market/tests/unit/test_matcher.py
+++ b/flocx_market/tests/unit/test_matcher.py
@@ -169,5 +169,3 @@ def test_invalid_data_type():
     with raises(ValueError):
         exp = [["inventory.memory.physical_mb", "<=", "755-*37"]]
         match_specs(exp, data)
-        exp = [["inventory.system_vendor.product_name", "endswith", ["M620"]]]
-        match_specs(exp, data)


### PR DESCRIPTION
The test_invalid_data_type test included two calls to match_specs
inside a pytest `with raises` block. The second test would never run
(because the exception raised by the first call would exit the `with`
block).  This commit removes the second call to match_specs.

Closes #27