### PR TITLE
Implement common service to start up REST API

### DIFF
--- a/flocx_market/api/app.py
+++ b/flocx_market/api/app.py
@@ -1,20 +1,25 @@
-import pecan
-from pecan import make_app
-from flocx_market import model
-from flocx_market.api import config as api_config
+import os
+from flask import Flask
+from flask import Blueprint
+from flask import jsonify
+import flocx_market.conf
+CONF = flocx_market.conf.CONF
+flocx_market_api_bp = Blueprint("flocx_market_api_bp", __name__)
 
 
-def get_pecan_config():
-    filename = api_config.__file__.replace('.pyc', '.py')   # get the absolute path of the pecan config.py
-    return pecan.configuration.conf_from_file(filename)
+@flocx_market_api_bp.route('/')
+def index():
+    flocx_market_url = CONF.api.host_ip + ':' + str(CONF.api.port)
+    version = {"versions":
+               {"values": [{"status": "in progress",
+                            "updated": "2019-07-02T00:00:00Z",
+                            "media-types": [{"base": "application/json", "name": "flocx-market"}],
+                            "links": [{"href": flocx_market_url, "rel": "self"}]}]
+                }}
+    return jsonify(version)
 
 
-def setup_app():
-    config = get_pecan_config()
-    model.init_model()
-    app_conf = dict(config.app)
-    app = pecan.make_app(
-        app_conf.pop('root'),
-        logging=getattr(config, 'logging', {}),
-        **app_conf)
+def create_app(app_name):
+    app = Flask(app_name)
+    app.register_blueprint(flocx_market_api_bp)
     return app

--- a/flocx_market/api/service.py
+++ b/flocx_market/api/service.py
@@ -1,0 +1,51 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_concurrency import processutils
+from oslo_service import service
+from oslo_service import wsgi
+
+from flocx_market.api import app
+import flocx_market.conf
+
+
+CONF = flocx_market.conf.CONF
+
+
+class WSGIService(service.ServiceBase):
+
+    def __init__(self, name):
+        self.name = name
+        self.app = app.create_app(app_name='flocx-market')
+
+        self.workers = (
+            CONF.api.api_workers or processutils.get_worker_count()
+        )
+
+        self.server = wsgi.Server(
+            CONF, name, self.app,
+            host=CONF.api.host_ip,
+            port=CONF.api.port,
+            use_ssl=CONF.api.enable_ssl_api
+        )
+
+    def start(self):
+        self.server.start()
+
+    def stop(self):
+        self.server.stop()
+
+    def wait(self):
+        self.server.wait()
+
+    def reset(self):
+        self.server.reset()

--- a/flocx_market/cmd/api.py
+++ b/flocx_market/cmd/api.py
@@ -1,16 +1,29 @@
-from wsgiref import simple_server
-from flocx_market.api import app
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import sys
+
+from oslo_service import service
+
+from flocx_market.api import service as wsgi_service
+from flocx_market.common import service as flocx_market_service
+import flocx_market.conf
+
+CONF = flocx_market.conf.CONF
 
 
 def main():
-    host = '0.0.0.0'
-    port = 8080
-
-    application = app.setup_app()
-    srv = simple_server.make_server(host, port, application)
-    print('Server on port 8080, listening...')
-    srv.serve_forever()
-
-
-if __name__ == '__main__':
-    main()
+    flocx_market_service.prepare_service(sys.argv)
+    # Build and start the WSGI app
+    launcher = service.ProcessLauncher(CONF, restart_method='mutate')
+    server = wsgi_service.WSGIService('flocx_market_api')
+    launcher.launch_service(server, workers=server.workers)
+    launcher.wait()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # process, which may cause wedges in the gate later.
 pbr!=2.1.0,>=2.0.0 # Apache-2.0
 pycodestyle>=2.5.0
-Pecan>=1.3.3
+Flask>=1.0.3
 alembic>=0.8.10 # MIT
 keystonemiddleware>=4.17.0 # Apache-2.0
 SQLAlchemy!=1.1.5,!=1.1.6,!=1.1.7,!=1.1.8,>=1.0.10 # MIT

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ packages =
     flocx_market
 
 [entry_points]
-esi_leap.database.migration_backend =
-	#sqlalchemy = esi_leap.db.sqlalchemy.migration
 oslo.config.opts =
     flocx-market.conf = flocx_market.conf.opts:list_opts
+console_scripts =
+    flocx-market-api = flocx_market.cmd.api:main


### PR DESCRIPTION
Run cmd: flocx-market-api, then the app is start by the script cmd/start_service.py
- TG-86