### PR TITLE
Add Keystone authentication to REST API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ etc/flocx-market/flocx-market.conf.sample
 *.pyc
 __pycache__/
 .tox/
+.coverage

--- a/flocx_market/api/app.py
+++ b/flocx_market/api/app.py
@@ -4,6 +4,7 @@ from flocx_market.api.offer import Offer
 from flocx_market.api.root import Root
 import flocx_market.conf
 
+from keystonemiddleware import auth_token
 
 CONF = flocx_market.conf.CONF
 
@@ -21,4 +22,8 @@ def create_app(app_name):
                      '/offer/',
                      '/offer/<string:marketplace_offer_id>')
     api.add_resource(Root, '/')
+
+    if CONF.api.auth_enable:
+        app = auth_token.AuthProtocol(app, dict(CONF.keystone_authtoken))
+
     return app

--- a/flocx_market/cmd/api.py
+++ b/flocx_market/cmd/api.py
@@ -27,3 +27,7 @@ def main():
     server = wsgi_service.WSGIService('flocx_market_api')
     launcher.launch_service(server, workers=server.workers)
     launcher.wait()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/flocx_market/tests/unit/api/test_app.py
+++ b/flocx_market/tests/unit/api/test_app.py
@@ -1,8 +1,9 @@
 import json
-
 import flocx_market.conf
 
 CONF = flocx_market.conf.CONF
+CONF.set_override("auth_enable", False,
+                  group='api')
 
 
 def test_root_status_code(client):


### PR DESCRIPTION
Uses the keystonemiddleware package to require any user to have a valid
token in order to query the api. Need to add tests for this still (and
could use direction in doing so as this commit isn't self contained. It
depends on the config file at /etc/flocx-market as well as deploying
an application on a port)