### PR TITLE
Add Missing Eventlet Requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # Please keep this file sorted alphabetically.
 
 alembic>=0.8.10 # MIT
-flake8>= 3.7.7 
+flake8>= 3.7.7
+eventlet==0.24.1
 Flask>=1.0.3
 jmespath>=0.9.4
 keystonemiddleware>=4.17.0 # Apache-2.0


### PR DESCRIPTION
The use of eventlet in the init.py in flocx-market/cmd was not recorded
into the requirements.txt of the already merged pull request. TG-86