### PR TITLE
Correct behavior of the Offer REST API

### DIFF
--- a/flocx_market/api/app.py
+++ b/flocx_market/api/app.py
@@ -16,6 +16,6 @@ def create_app(app_name):
     )
     app.config['PROPAGATE_EXCEPTIONS'] = CONF.flask.PROPAGATE_EXCEPTIONS
     api = Api(app)
-    api.add_resource(Offer, '/offer', '/offers/<string:marketplace_offer_id>')
+    api.add_resource(Offer, '/offer', '/offer/<string:marketplace_offer_id>')
     api.add_resource(Root, '/')
     return app

--- a/flocx_market/api/app.py
+++ b/flocx_market/api/app.py
@@ -16,6 +16,9 @@ def create_app(app_name):
     )
     app.config['PROPAGATE_EXCEPTIONS'] = CONF.flask.PROPAGATE_EXCEPTIONS
     api = Api(app)
-    api.add_resource(Offer, '/offer', '/offer/<string:marketplace_offer_id>')
+    api.add_resource(Offer,
+                     '/offer',
+                     '/offer/',
+                     '/offer/<string:marketplace_offer_id>')
     api.add_resource(Root, '/')
     return app

--- a/flocx_market/api/offer.py
+++ b/flocx_market/api/offer.py
@@ -6,7 +6,10 @@ from flocx_market.db.sqlalchemy.offer_api import OfferApi
 class Offer(Resource):
 
     @classmethod
-    def get(cls, marketplace_offer_id):
+    def get(cls, marketplace_offer_id=None):
+        if marketplace_offer_id is None:
+            return OfferList.get()
+
         offer = OfferApi.find_by_id(marketplace_offer_id)
         if offer:
             return offer.as_dict()
@@ -32,6 +35,9 @@ class Offer(Resource):
     def put(cls, marketplace_offer_id):
         data = request.get_json(force=True)
         offer = OfferApi.find_by_id(marketplace_offer_id)
+        if offer is None:
+            return {'message': 'Offer not found'}, 404
+
         offer.status = data['status']
         offer.save_to_db()
         return offer.as_dict()

--- a/flocx_market/api/offer.py
+++ b/flocx_market/api/offer.py
@@ -8,7 +8,7 @@ class Offer(Resource):
     @classmethod
     def get(cls, marketplace_offer_id=None):
         if marketplace_offer_id is None:
-            return OfferList.get()
+            return OfferList.get()['offers']
 
         offer = OfferApi.find_by_id(marketplace_offer_id)
         if offer:
@@ -18,8 +18,7 @@ class Offer(Resource):
     @classmethod
     def post(cls):
         data = request.get_json(force=True)
-        data_for_offer = [x for x in data.values()]
-        offer = OfferApi(*data_for_offer)
+        offer = OfferApi(**data)
         offer.save_to_db()
         return offer.as_dict(), 201
 

--- a/flocx_market/tests/unit/api/test_app.py
+++ b/flocx_market/tests/unit/api/test_app.py
@@ -1,33 +1,17 @@
 import json
-import pytest
 
-from oslo_config import cfg
-
-import flocx_market.api.app
 import flocx_market.conf
 
 CONF = flocx_market.conf.CONF
 
 
-@pytest.fixture
-def test_app():
-    CONF.set_override("auth_enable", False,
-                      group='api')
-    connection_opt = cfg.StrOpt("connection", None)
-    CONF.register_opt(connection_opt, group="database")
-    app = flocx_market.api.app.create_app(app_name="test").test_client()
-    app.testing = True
-    yield app
-    CONF.unregister_opt(connection_opt, group="database")
-
-
-def test_root_status_code(test_app):
-    response = test_app.get("/", follow_redirects=True)
+def test_root_status_code(client):
+    response = client.get("/", follow_redirects=True)
     assert response.status_code == 200
 
 
-def test_root_data(test_app):
-    response = test_app.get("/", follow_redirects=True)
+def test_root_data(client):
+    response = client.get("/", follow_redirects=True)
     flocx_market_url = CONF.api.host_ip + ":" + str(CONF.api.port)
     version = {
         "versions": {

--- a/flocx_market/tests/unit/api/test_app_offer.py
+++ b/flocx_market/tests/unit/api/test_app_offer.py
@@ -43,12 +43,11 @@ def test_get_offers(mock_query, client):
     mock_query.all.return_value = test_result
     response = client.get("/offer", follow_redirects=True)
     assert response.status_code == 200
-    assert 'offers' in response.json
-    assert len(response.json['offers']) == 2
+    assert len(response.json) == 2
     assert any(x['provider_id'] == test_offer_1.provider_id
-               for x in response.json['offers'])
+               for x in response.json)
     assert any(x['provider_id'] == test_offer_2.provider_id
-               for x in response.json['offers'])
+               for x in response.json)
 
 
 @mock.patch('flocx_market.api.offer.OfferApi.find_by_id')

--- a/flocx_market/tests/unit/api/test_app_offer.py
+++ b/flocx_market/tests/unit/api/test_app_offer.py
@@ -110,6 +110,6 @@ def test_update_offer_missing(mock_save_to_db, mock_find_by_id,
                               client):
     mock_find_by_id.return_value = None
     res = client.put('/offer/does-not-exist',
-        data=json.dumps(dict(status='testing')))
+                     data=json.dumps(dict(status='testing')))
     assert res.status_code == 404
     assert mock_save_to_db.call_count == 0

--- a/flocx_market/tests/unit/api/test_app_offer.py
+++ b/flocx_market/tests/unit/api/test_app_offer.py
@@ -1,0 +1,116 @@
+import datetime
+import json
+from unittest import mock
+
+import flocx_market.conf
+from flocx_market.db.sqlalchemy.offer_api import OfferApi
+
+CONF = flocx_market.conf.CONF
+
+now = datetime.datetime.utcnow()
+
+
+test_offer_1 = OfferApi(
+    marketplace_date_created=now,
+    marketplace_offer_id='test_offer_1',
+    provider_id='1234',
+    creator_id='2345',
+    server_id='3456',
+    start_time=now,
+    end_time=now,
+    status='available',
+    server_config={'bar': 'foo'},
+    cost=0.0,
+)
+
+test_offer_2 = OfferApi(
+    marketplace_offer_id='test_offer_2',
+    marketplace_date_created=now,
+    provider_id='2345',
+    creator_id='3456',
+    server_id='4567',
+    start_time=now,
+    end_time=now,
+    status='available',
+    server_config={'foo': 'bar'},
+    cost=0.0,
+)
+
+
+@mock.patch('flocx_market.api.offer.OfferApi.query')
+def test_get_offers(mock_query, client):
+    test_result = [test_offer_1, test_offer_2]
+    mock_query.all.return_value = test_result
+    response = client.get("/offer", follow_redirects=True)
+    assert response.status_code == 200
+    assert 'offers' in response.json
+    assert len(response.json['offers']) == 2
+    assert any(x['provider_id'] == test_offer_1.provider_id
+               for x in response.json['offers'])
+    assert any(x['provider_id'] == test_offer_2.provider_id
+               for x in response.json['offers'])
+
+
+@mock.patch('flocx_market.api.offer.OfferApi.find_by_id')
+def test_get_offer(mock_find_by_id, client):
+    mock_find_by_id.return_value = test_offer_1
+    response = client.get('/offer/{}'.format(
+        test_offer_1.marketplace_offer_id))
+    assert response.status_code == 200
+    mock_find_by_id.assert_called_with('test_offer_1')
+    assert response.json['marketplace_offer_id'] == 'test_offer_1'
+
+
+@mock.patch('flocx_market.api.offer.OfferApi.find_by_id')
+def test_get_offer_missing(mock_find_by_id, client):
+    mock_find_by_id.return_value = None
+    response = client.get('/offer/does-not-exist')
+    assert response.status_code == 404
+
+
+@mock.patch('flocx_market.api.offer.OfferApi.find_by_id')
+@mock.patch('flocx_market.api.offer.OfferApi.delete_from_db')
+def test_delete_offer(mock_delete_from_db, mock_find_by_id, client):
+    mock_find_by_id.return_value = test_offer_1
+    response = client.delete('/offer/{}'.format(
+        test_offer_1.marketplace_offer_id))
+    assert response.status_code == 200
+    assert mock_delete_from_db.call_count == 1
+
+
+@mock.patch('flocx_market.api.offer.OfferApi.find_by_id')
+def test_delete_offer_missing(mock_find_by_id, client):
+    mock_find_by_id.return_value = None
+    response = client.delete('/offer/does-not-exist')
+    assert response.status_code == 404
+
+
+@mock.patch('flocx_market.api.offer.OfferApi')
+@mock.patch('flocx_market.api.offer.OfferApi.save_to_db')
+def test_create_offer(mock_save_to_db, mock_offer, client):
+    mock_offer.return_value = test_offer_1
+    res = client.post('/offer', data=json.dumps(test_offer_1.as_dict()))
+    assert res.status_code == 201
+    assert mock_save_to_db.call_count == 1
+    assert res.json == test_offer_1.as_dict()
+
+
+@mock.patch('flocx_market.api.offer.OfferApi')
+@mock.patch('flocx_market.api.offer.OfferApi.save_to_db')
+def test_update_offer(mock_save_to_db, mock_offer, client):
+    mock_offer.return_value = test_offer_1
+    res = client.post('/offer', data=json.dumps(test_offer_1.as_dict()))
+    assert res.status_code == 201
+    assert mock_save_to_db.call_count == 1
+    assert res.json == test_offer_1.as_dict()
+
+
+@mock.patch('flocx_market.api.offer.OfferApi.find_by_id')
+@mock.patch('flocx_market.api.offer.OfferApi.save_to_db')
+def test_update_offer_missing(mock_save_to_db, mock_find_by_id,
+                              client):
+    mock_find_by_id.return_value = None
+    res = client.put('/offer/does-not-exist',
+        data=json.dumps(dict(status='testing')))
+    assert res.status_code == 404
+    assert mock_save_to_db.call_count == 0

--- a/flocx_market/tests/unit/conftest.py
+++ b/flocx_market/tests/unit/conftest.py
@@ -7,8 +7,6 @@ from flocx_market.db.orm import orm
 
 
 class test_app_config:
-    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
-    SQLALCHEMY_TRACK_MODIFICATIONS = True
     TESTING = True
 
 
@@ -18,11 +16,19 @@ def app():
     prepare_service()
     CONF.database.connection = 'sqlite:///:memory:'
     app = create_app('testing')
+    app.config.from_object(test_app_config)
     orm.init_app(app)
     ctx = app.app_context()
     ctx.push()
     yield app
     ctx.push()
+
+
+@pytest.fixture(scope='session')
+def client(app):
+    _client = app.test_client()
+    _client.testing = True
+    return _client
 
 
 @pytest.fixture()


### PR DESCRIPTION
Requests to `offer/` should return a list of available offers. Prior to
this commit, the API would return an error for requests to `/offer`.

Closes #64