### PR TITLE
Corrected behavior of get and post endpoints for offer API

### DIFF
--- a/flocx_market/api/offer.py
+++ b/flocx_market/api/offer.py
@@ -6,7 +6,10 @@ from flocx_market.db.sqlalchemy.offer_api import OfferApi
 class Offer(Resource):
 
     @classmethod
-    def get(cls, marketplace_offer_id):
+    def get(cls, marketplace_offer_id=None):
+        if marketplace_offer_id is None:
+            return OfferList.get()['offers']
+
         offer = OfferApi.find_by_id(marketplace_offer_id)
         if offer:
             return offer.as_dict()
@@ -15,8 +18,7 @@ class Offer(Resource):
     @classmethod
     def post(cls):
         data = request.get_json(force=True)
-        data_for_offer = [x for x in data.values()]
-        offer = OfferApi(*data_for_offer)
+        offer = OfferApi(**data)
         offer.save_to_db()
         return offer.as_dict(), 201
 


### PR DESCRIPTION
After removing the __init__ method from offer_api, we needed to change up the post method to adjust to the new changes and have it working with the database. The get method has also been adjusted to handle get request with nothing passed in as offer id. 