### PR TITLE
Fixed up flake8 errors and create_invalid test for the offer API

### DIFF
--- a/flocx_market/tests/unit/common/test_service.py
+++ b/flocx_market/tests/unit/common/test_service.py
@@ -39,12 +39,12 @@ def test_service_cli_valid(find_config_files):
            str(args[args.index('--api-public_endpoint') + 1]))
     assert(CONF.api.api_workers ==
            int(args[args.index('--api-api_workers') + 1]))
-    assert(CONF.api.enable_ssl_api)
+    assert(CONF.api.enable_ssl_api is True)
 
     assert(CONF.api.max_limit == 1000)
 
     assert(CONF.flask.SQLALCHEMY_TRACK_MODIFICATIONS is False)
-    assert(CONF.flask.PROPAGATE_EXCEPTIONS)
+    assert(CONF.flask.PROPAGATE_EXCEPTIONS is True)
 
     assert(CONF.host == str(args[args.index('--host') + 1]))
 

--- a/flocx_market/tests/unit/db/sqlalchemy/test_offer_api.py
+++ b/flocx_market/tests/unit/db/sqlalchemy/test_offer_api.py
@@ -8,13 +8,13 @@ from sqlalchemy.exc import IntegrityError
 
 now = datetime.datetime.utcnow()
 test_offer_data = dict(
-    marketplace_date_created=now,
     provider_id='2345',
     creator_id='3456',
+    marketplace_date_created=now,
+    status='available',
     server_id='4567',
     start_time=now,
     end_time=now,
-    status='available',
     server_config={'foo': 'bar'},
     cost=0.0,
 )

--- a/flocx_market/tests/unit/unit_base_test.py
+++ b/flocx_market/tests/unit/unit_base_test.py
@@ -1,5 +1,0 @@
-from unittest import TestCase
-
-
-class UnitBaseTest(TestCase):
-    pass


### PR DESCRIPTION
Fixed up flake8 errors in in tests/unit/common/test_service.py.
Fixed up test_offer_api: changed the order of
data in data creation and test_create_invalid.py