### PR TITLE
Block pull requests with fixup commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 install:
   - pip install tox codecov
 script:
-  - tox -q -e commit
+  - tox -q -e commit -- --block-fixups
   - tox -q
 
 after_script:

--- a/flocx_market/tests/commit/conftest.py
+++ b/flocx_market/tests/commit/conftest.py
@@ -8,3 +8,10 @@ def pytest_addoption(parser):
         action='store',
         help='Read commit message from named file'
     )
+
+    parser.addoption(
+        '--block-fixups',
+        action='store_true',
+        default=False,
+        help='Block fixup commits',
+    )

--- a/flocx_market/tests/commit/test_commit_message.py
+++ b/flocx_market/tests/commit/test_commit_message.py
@@ -155,3 +155,10 @@ def test_commit_has_reference(commit_message):
         'Use TG-nn to reference a Taiga task/story, or #nnn to reference a '
         'GitHub issue.'
     )
+
+
+def test_commit_not_fixup(commit_message, request):
+    if not request.config.option.block_fixups:
+        pytest.skip('Use --block-fixups to block fixup commits')
+
+    assert not commit_message.startswith('fixup!')


### PR DESCRIPTION
Commit e4d83a2e shouldn't have landed. This commits adds a check to CI
that will fail if a pull request contains a fixup! commit.

Closes #69