### PR TITLE
Removed OfferApi database model

### DIFF
--- a/flocx_market/api/offer.py
+++ b/flocx_market/api/offer.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from flocx_market.db.sqlalchemy import offer_api
+from flocx_market.db.sqlalchemy import api as dbapi
 
 
 class Offer(Resource):
@@ -10,7 +10,7 @@ class Offer(Resource):
         if marketplace_offer_id is None:
             return OfferList.get()['offers']
 
-        offer = offer_api.get(marketplace_offer_id)
+        offer = dbapi.offer_get(marketplace_offer_id)
         if offer:
             return offer.to_dict()
         return {'message': 'Offer not found'}, 404
@@ -18,30 +18,30 @@ class Offer(Resource):
     @classmethod
     def post(cls):
         data = request.get_json(force=True)
-        offer = offer_api.create(**data)
+        offer = dbapi.offer_create(**data)
         return offer.to_dict(), 201
 
     @classmethod
     def delete(cls, marketplace_offer_id):
-        offer = offer_api.get(marketplace_offer_id)
+        offer = dbapi.offer_get(marketplace_offer_id)
         if offer:
-            offer_api.destroy(marketplace_offer_id)
+            dbapi.offer_destroy(marketplace_offer_id)
             return {'message': 'Offer deleted.'}
         return {'message': 'Offer not found.'}, 404
 
     @classmethod
     def put(cls, marketplace_offer_id):
         data = request.get_json(force=True)
-        offer = offer_api.get(marketplace_offer_id)
+        offer = dbapi.offer_get(marketplace_offer_id)
         if offer is None:
             return {'message': 'Offer not found'}, 404
 
         offer.status = data['status']
-        offer_api.update(marketplace_offer_id, offer.to_dict())
+        dbapi.offer_update(marketplace_offer_id, offer.to_dict())
         return offer.to_dict()
 
 
 class OfferList(Resource):
     @classmethod
     def get(cls):
-        return {"offers": [x.to_dict() for x in offer_api.get_all()]}
+        return {"offers": [x.to_dict() for x in dbapi.offer_get_all()]}

--- a/flocx_market/db/sqlalchemy/api.py
+++ b/flocx_market/db/sqlalchemy/api.py
@@ -1,36 +1,36 @@
 from oslo_utils import uuidutils
 
 from flocx_market.db.orm import orm
-from flocx_market.db.sqlalchemy.offer_model import OfferModel
+from flocx_market.db.sqlalchemy import models
 
 
-def get(marketplace_offer_id):
-    return OfferModel.query.filter_by(
+def offer_get(marketplace_offer_id):
+    return models.Offer.query.filter_by(
         marketplace_offer_id=marketplace_offer_id).first()
 
 
-def get_all():
-    return OfferModel.query.all()
+def offer_get_all():
+    return models.Offer.query.all()
 
 
-def create(values):
+def offer_create(values):
     values['marketplace_offer_id'] = uuidutils.generate_uuid()
-    offer_ref = OfferModel(**values)
+    offer_ref = models.Offer(**values)
     orm.session.add(offer_ref)
     orm.session.commit()
     return offer_ref
 
 
-def update(marketplace_offer_id, values):
+def offer_update(marketplace_offer_id, values):
     values.pop('marketplace_offer_id', None)
-    OfferModel.query.filter_by(
+    models.Offer.query.filter_by(
         marketplace_offer_id=marketplace_offer_id).update(values)
     orm.session.commit()
-    return get(marketplace_offer_id)
+    return offer_get(marketplace_offer_id)
 
 
-def destroy(marketplace_offer_id):
-    offer_ref = get(marketplace_offer_id)
+def offer_destroy(marketplace_offer_id):
+    offer_ref = offer_get(marketplace_offer_id)
     if offer_ref:
         orm.session.delete(offer_ref)
         orm.session.commit()

--- a/flocx_market/db/sqlalchemy/models.py
+++ b/flocx_market/db/sqlalchemy/models.py
@@ -2,7 +2,7 @@ from flocx_market.db.orm import orm
 import sqlalchemy_jsonfield
 
 
-class OfferModel(orm.Model):
+class Offer(orm.Model):
     __tablename__ = "offers"
     marketplace_offer_id = orm.Column(
         orm.String(64),

--- a/flocx_market/db/sqlalchemy/offer_model.py
+++ b/flocx_market/db/sqlalchemy/offer_model.py
@@ -1,5 +1,3 @@
-import uuid
-
 from flocx_market.db.orm import orm
 import sqlalchemy_jsonfield
 
@@ -10,7 +8,6 @@ class OfferModel(orm.Model):
         orm.String(64),
         primary_key=True,
         autoincrement=False,
-        default=lambda: uuid.uuid4().hex,
     )
     provider_id = orm.Column(orm.String(64), nullable=False)
     creator_id = orm.Column(orm.String(64), nullable=False)
@@ -26,3 +23,14 @@ class OfferModel(orm.Model):
         nullable=False,
     )
     cost = orm.Column(orm.Float, nullable=False)
+
+    def to_dict(self):
+        d = {}
+        for col in self.__table__.columns:
+            if col.name in [
+                    'marketplace_date_created', 'start_time', 'end_time'
+            ]:
+                d[col.name] = getattr(self, col.name).isoformat()
+            else:
+                d[col.name] = getattr(self, col.name)
+        return d

--- a/flocx_market/tests/unit/api/test_app_offer.py
+++ b/flocx_market/tests/unit/api/test_app_offer.py
@@ -3,7 +3,7 @@ import json
 from unittest import mock
 
 import flocx_market.conf
-from flocx_market.db.sqlalchemy.offer_model import OfferModel
+from flocx_market.db.sqlalchemy import models
 
 
 CONF = flocx_market.conf.CONF
@@ -11,7 +11,7 @@ CONF = flocx_market.conf.CONF
 now = datetime.datetime.utcnow()
 
 
-test_offer_1 = OfferModel(
+test_offer_1 = models.Offer(
     marketplace_date_created=now,
     marketplace_offer_id='test_offer_1',
     provider_id='1234',
@@ -24,7 +24,7 @@ test_offer_1 = OfferModel(
     cost=0.0,
 )
 
-test_offer_2 = OfferModel(
+test_offer_2 = models.Offer(
     marketplace_offer_id='test_offer_2',
     marketplace_date_created=now,
     provider_id='2345',
@@ -38,7 +38,7 @@ test_offer_2 = OfferModel(
 )
 
 
-@mock.patch('flocx_market.db.sqlalchemy.offer_api.get_all')
+@mock.patch('flocx_market.db.sqlalchemy.api.offer_get_all')
 def test_get_offers(mock_get_all, client):
     test_result = [test_offer_1, test_offer_2]
     mock_get_all.return_value = test_result
@@ -51,7 +51,7 @@ def test_get_offers(mock_get_all, client):
                for x in response.json)
 
 
-@mock.patch('flocx_market.db.sqlalchemy.offer_api.get')
+@mock.patch('flocx_market.db.sqlalchemy.api.offer_get')
 def test_get_offer(mock_get, client):
     mock_get.return_value = test_offer_1
     response = client.get('/offer/{}'.format(
@@ -61,15 +61,15 @@ def test_get_offer(mock_get, client):
     assert response.json['marketplace_offer_id'] == 'test_offer_1'
 
 
-@mock.patch('flocx_market.db.sqlalchemy.offer_api.get')
+@mock.patch('flocx_market.db.sqlalchemy.api.offer_get')
 def test_get_offer_missing(mock_get, client):
     mock_get.return_value = None
     response = client.get('/offer/does-not-exist')
     assert response.status_code == 404
 
 
-@mock.patch('flocx_market.db.sqlalchemy.offer_api.destroy')
-@mock.patch('flocx_market.db.sqlalchemy.offer_api.get')
+@mock.patch('flocx_market.db.sqlalchemy.api.offer_destroy')
+@mock.patch('flocx_market.db.sqlalchemy.api.offer_get')
 def test_delete_offer(mock_get, mock_destroy, client):
     mock_get.return_value = test_offer_1
     response = client.delete('/offer/{}'.format(
@@ -78,14 +78,14 @@ def test_delete_offer(mock_get, mock_destroy, client):
     assert mock_destroy.call_count == 1
 
 
-@mock.patch('flocx_market.db.sqlalchemy.offer_api.get')
+@mock.patch('flocx_market.db.sqlalchemy.api.offer_get')
 def test_delete_offer_missing(mock_get, client):
     mock_get.return_value = None
     response = client.delete('/offer/does-not-exist')
     assert response.status_code == 404
 
 
-@mock.patch('flocx_market.db.sqlalchemy.offer_api.create')
+@mock.patch('flocx_market.db.sqlalchemy.api.offer_create')
 def test_create_offer(mock_create, client):
     mock_create.return_value = test_offer_1
     res = client.post('/offer', data=json.dumps(test_offer_1.to_dict()))
@@ -94,8 +94,8 @@ def test_create_offer(mock_create, client):
     assert res.json == test_offer_1.to_dict()
 
 
-@mock.patch('flocx_market.db.sqlalchemy.offer_api.update')
-@mock.patch('flocx_market.db.sqlalchemy.offer_api.get')
+@mock.patch('flocx_market.db.sqlalchemy.api.offer_update')
+@mock.patch('flocx_market.db.sqlalchemy.api.offer_get')
 def test_update_offer(mock_get, mock_update, client):
     mock_get.return_value = test_offer_1
     mock_update.return_value = test_offer_1
@@ -106,8 +106,8 @@ def test_update_offer(mock_get, mock_update, client):
     assert res.json['status'] == 'testing'
 
 
-@mock.patch('flocx_market.db.sqlalchemy.offer_api.update')
-@mock.patch('flocx_market.db.sqlalchemy.offer_api.get')
+@mock.patch('flocx_market.db.sqlalchemy.api.offer_update')
+@mock.patch('flocx_market.db.sqlalchemy.api.offer_get')
 def test_update_offer_missing(mock_get, mock_update, client):
     mock_get.return_value = None
     res = client.put('/offer/does-not-exist',

--- a/flocx_market/tests/unit/db/sqlalchemy/test_api.py
+++ b/flocx_market/tests/unit/db/sqlalchemy/test_api.py
@@ -1,7 +1,7 @@
 import datetime
 import pytest
 
-from flocx_market.db.sqlalchemy import offer_api
+from flocx_market.db.sqlalchemy import api
 
 from sqlalchemy.exc import IntegrityError
 
@@ -21,8 +21,8 @@ test_offer_data = dict(
 
 
 def test_offer_create(app, db, session):
-    offer = offer_api.create(test_offer_data)
-    check = offer_api.get(offer.marketplace_offer_id)
+    offer = api.offer_create(test_offer_data)
+    check = api.offer_get(offer.marketplace_offer_id)
 
     assert check.to_dict() == offer.to_dict()
 
@@ -32,21 +32,21 @@ def test_offer_create_invalid(app, db, session):
     del data['provider_id']
 
     with pytest.raises(IntegrityError):
-        offer_api.create(data)
+        api.offer_create(data)
 
 
 def test_offer_delete(app, db, session):
-    offer = offer_api.create(test_offer_data)
-    offer_api.destroy(offer.marketplace_offer_id)
-    check = offer_api.get(offer.marketplace_offer_id)
+    offer = api.offer_create(test_offer_data)
+    api.offer_destroy(offer.marketplace_offer_id)
+    check = api.offer_get(offer.marketplace_offer_id)
     assert check is None
 
 
 def test_offer_update(app, db, session):
-    offer = offer_api.create(test_offer_data)
-    offer = offer_api.update(
+    offer = api.offer_create(test_offer_data)
+    offer = api.offer_update(
         offer.marketplace_offer_id, dict(status='testing'))
-    check = offer_api.get(offer.marketplace_offer_id)
+    check = api.offer_get(offer.marketplace_offer_id)
 
     assert check.status == 'testing'
     assert check.creator_id == '3456'


### PR DESCRIPTION
The OfferApi model doesn't make sense as a way to run database operations
on an Offer. This change removes the class and puts those operations as
single functions within flocx_market/db/sqlalchemy/offer_api.py, as well
as moving the to_dict() function into the offer model. Lastly, it adds a
test for offer updates.

Addresses #73