### PR TITLE
Keystone Authentication bugfix

### DIFF
--- a/flocx_market/api/app.py
+++ b/flocx_market/api/app.py
@@ -1,8 +1,10 @@
 from flask import Flask
 from flask_restful import Api
+from flask_migrate import Migrate
 from flocx_market.api.offer import Offer
 from flocx_market.api.root import Root
 from flocx_market.api.bid import Bid
+from flocx_market.db.orm import orm
 import flocx_market.conf
 
 from keystonemiddleware import auth_token
@@ -27,6 +29,9 @@ def create_app(app_name):
                      '/bid/',
                      '/bid/<string:marketplace_bid_id>')
     api.add_resource(Root, '/')
+
+    Migrate(app, orm)
+    orm.init_app(app)
 
     if CONF.api.auth_enable:
         app = auth_token.AuthProtocol(app, dict(CONF.keystone_authtoken))

--- a/flocx_market/api/service.py
+++ b/flocx_market/api/service.py
@@ -13,9 +13,7 @@
 from oslo_concurrency import processutils
 from oslo_service import service
 from oslo_service import wsgi
-from flask_migrate import Migrate
 from flocx_market.api import app
-from flocx_market.db.orm import orm
 import flocx_market.conf
 
 
@@ -27,8 +25,6 @@ class WSGIService(service.ServiceBase):
     def __init__(self, name):
         self.name = name
         self.app = app.create_app(app_name='flocx-market')
-        Migrate(self.app, orm)
-        orm.init_app(self.app)
 
         self.workers = (
             CONF.api.api_workers or processutils.get_worker_count()

--- a/flocx_market/tests/unit/api/test_app.py
+++ b/flocx_market/tests/unit/api/test_app.py
@@ -2,8 +2,6 @@ import json
 import flocx_market.conf
 
 CONF = flocx_market.conf.CONF
-CONF.set_override("auth_enable", False,
-                  group='api')
 
 
 def test_root_status_code(client):

--- a/flocx_market/tests/unit/cmd/test_api_service.py
+++ b/flocx_market/tests/unit/cmd/test_api_service.py
@@ -1,0 +1,19 @@
+import flocx_market.conf
+from unittest import mock
+import flocx_market.cmd.api as main
+
+CONF = flocx_market.conf.CONF
+
+
+@mock.patch('flocx_market.cmd.api.flocx_market_service.prepare_service')
+@mock.patch('flocx_market.cmd.api.service.ProcessLauncher.launch_service')
+@mock.patch('flocx_market.cmd.api.service.ProcessLauncher.wait')
+def test_keystone_app(wait, launch, prepare):
+    CONF.clear()
+    CONF.set_override("auth_enable", True,
+                      group='api')
+
+    main.main()
+
+    launch.assert_called_once()
+    wait.assert_called_once()

--- a/flocx_market/tests/unit/conftest.py
+++ b/flocx_market/tests/unit/conftest.py
@@ -15,6 +15,9 @@ class test_app_config:
 @pytest.fixture(scope='session')
 def app():
     CONF.clear()
+    CONF.set_override("auth_enable", False,
+                      group='api')
+
     prepare_service()
     CONF.set_override('connection', 'sqlite:///:memory:',
                       group='database')

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ eventlet==0.24.1
 flake8>= 3.7.7
 Flask>=1.0.3
 flask-migrate>=2.5.2
-Flask-RESTful>=0.3.7  
+Flask-RESTful>=0.3.7
 Flask-SQLAlchemy>=2.4.0  
 itsdangerous>=1.1.0
 Jinja2>=2.10.1


### PR DESCRIPTION
This commit fixes a bug introduced with the keystone authentication.The
applications served when CONF.auth_enable was set to true was causing
issues with the wsgi_service, which was expecting a Flask App object, as
opposed to a keystonemiddleware Auth_Protocol object. TG-86