### PR TITLE
Remove database migration from REST API app

### DIFF
--- a/flocx_market/api/app.py
+++ b/flocx_market/api/app.py
@@ -1,6 +1,5 @@
 from flask import Flask
 from flask_restful import Api
-from flask_migrate import Migrate
 from flocx_market.api.offer import Offer
 from flocx_market.api.root import Root
 from flocx_market.api.bid import Bid
@@ -30,7 +29,6 @@ def create_app(app_name):
                      '/bid/<string:marketplace_bid_id>')
     api.add_resource(Root, '/')
 
-    Migrate(app, orm)
     orm.init_app(app)
 
     if CONF.api.auth_enable:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ alembic>=0.8.10 # MIT
 eventlet==0.24.1
 flake8>= 3.7.7
 Flask>=1.0.3
-flask-migrate>=2.5.2
 Flask-RESTful>=0.3.7
 Flask-SQLAlchemy>=2.4.0  
 itsdangerous>=1.1.0


### PR DESCRIPTION
The database migration can be removed from the REST API app now
that there is a separate flocx-market-dbsync script.

Addresses #83