### PR TITLE
Update business object save code to use oslo versionedobject code

### DIFF
--- a/flocx_market/api/bid.py
+++ b/flocx_market/api/bid.py
@@ -34,4 +34,8 @@ class Bid(Resource):
         b = bid.Bid.get(marketplace_bid_id)
         if b is None:
             return {'message': 'Bid not found.'}, 404
-        return b.save(data).to_dict()
+        # we only allow status field to be modified
+        if 'status' in data:
+            b.status = data['status']
+            return b.save().to_dict()
+        return b.to_dict()

--- a/flocx_market/api/offer.py
+++ b/flocx_market/api/offer.py
@@ -34,4 +34,8 @@ class Offer(Resource):
         o = offer.Offer.get(marketplace_offer_id)
         if o is None:
             return {'message': 'Offer not found.'}, 404
-        return o.save(data).to_dict()
+        # we only allow status field to be modified
+        if 'status' in data:
+            o.status = data['status']
+            return o.save().to_dict()
+        return o.to_dict()

--- a/flocx_market/objects/bid.py
+++ b/flocx_market/objects/bid.py
@@ -1,8 +1,11 @@
+from oslo_versionedobjects import base as versioned_objects_base
+
 import flocx_market.db.sqlalchemy.api as db
 from flocx_market.objects import base
 from flocx_market.objects import fields
 
 
+@versioned_objects_base.VersionedObjectRegistry.register
 class Bid(base.FLOCXMarketObject):
 
     fields = {
@@ -34,8 +37,8 @@ class Bid(base.FLOCXMarketObject):
             else:
                 return cls._from_db_object(cls(), b)
 
-    def destroy(cls):
-        db.bid_destroy(cls.marketplace_bid_id)
+    def destroy(self):
+        db.bid_destroy(self.marketplace_bid_id)
         return True
 
     @classmethod
@@ -43,7 +46,8 @@ class Bid(base.FLOCXMarketObject):
         all_bids = db.bid_get_all()
         return cls._from_db_object_list(all_bids)
 
-    def save(cls, data):
-        cls.status = data['status']
-        db.bid_update(cls.marketplace_bid_id, data)
-        return cls
+    def save(self):
+        updates = self.obj_get_changes()
+        db_bid = db.bid_update(
+            self.marketplace_bid_id, updates)
+        return self._from_db_object(self, db_bid)

--- a/flocx_market/objects/offer.py
+++ b/flocx_market/objects/offer.py
@@ -1,8 +1,11 @@
+from oslo_versionedobjects import base as versioned_objects_base
+
 import flocx_market.db.sqlalchemy.api as db
 from flocx_market.objects import base
 from flocx_market.objects import fields
 
 
+@versioned_objects_base.VersionedObjectRegistry.register
 class Offer(base.FLOCXMarketObject):
 
     fields = {
@@ -34,8 +37,8 @@ class Offer(base.FLOCXMarketObject):
             else:
                 return cls._from_db_object(cls(), o)
 
-    def destroy(cls):
-        db.offer_destroy(cls.marketplace_offer_id)
+    def destroy(self):
+        db.offer_destroy(self.marketplace_offer_id)
         return True
 
     @classmethod
@@ -43,7 +46,8 @@ class Offer(base.FLOCXMarketObject):
         all_offers = db.offer_get_all()
         return cls._from_db_object_list(all_offers)
 
-    def save(cls, data):
-        cls.status = data['status']
-        db.offer_update(cls.marketplace_offer_id, data)
-        return cls
+    def save(self):
+        updates = self.obj_get_changes()
+        db_offer = db.offer_update(
+            self.marketplace_offer_id, updates)
+        return self._from_db_object(self, db_offer)

--- a/flocx_market/tests/unit/api/test_app_offer.py
+++ b/flocx_market/tests/unit/api/test_app_offer.py
@@ -3,7 +3,7 @@ import json
 from unittest import mock
 
 import flocx_market.conf
-from flocx_market.db.sqlalchemy import models
+from flocx_market.objects import offer
 
 
 CONF = flocx_market.conf.CONF
@@ -11,7 +11,7 @@ CONF = flocx_market.conf.CONF
 now = datetime.datetime.utcnow()
 
 
-test_offer_1 = models.Offer(
+test_offer_1 = offer.Offer(
     marketplace_date_created=now,
     marketplace_offer_id='test_offer_1',
     provider_id='1234',
@@ -24,7 +24,7 @@ test_offer_1 = models.Offer(
     cost=0.0,
 )
 
-test_offer_2 = models.Offer(
+test_offer_2 = offer.Offer(
     marketplace_offer_id='test_offer_2',
     marketplace_date_created=now,
     provider_id='2345',
@@ -38,7 +38,7 @@ test_offer_2 = models.Offer(
 )
 
 
-@mock.patch('flocx_market.db.sqlalchemy.api.offer_get_all')
+@mock.patch('flocx_market.objects.offer.Offer.get_all')
 def test_get_offers(mock_get_all, client):
     test_result = [test_offer_1, test_offer_2]
     mock_get_all.return_value = test_result
@@ -51,7 +51,7 @@ def test_get_offers(mock_get_all, client):
                for x in response.json)
 
 
-@mock.patch('flocx_market.db.sqlalchemy.api.offer_get')
+@mock.patch('flocx_market.objects.offer.Offer.get')
 def test_get_offer(mock_get, client):
     mock_get.return_value = test_offer_1
     response = client.get('/offer/{}'.format(
@@ -61,15 +61,15 @@ def test_get_offer(mock_get, client):
     assert response.json['marketplace_offer_id'] == 'test_offer_1'
 
 
-@mock.patch('flocx_market.db.sqlalchemy.api.offer_get')
+@mock.patch('flocx_market.objects.offer.Offer.get')
 def test_get_offer_missing(mock_get, client):
     mock_get.return_value = None
     response = client.get('/offer/does-not-exist')
     assert response.status_code == 404
 
 
-@mock.patch('flocx_market.db.sqlalchemy.api.offer_destroy')
-@mock.patch('flocx_market.db.sqlalchemy.api.offer_get')
+@mock.patch('flocx_market.objects.offer.Offer.destroy')
+@mock.patch('flocx_market.objects.offer.Offer.get')
 def test_delete_offer(mock_get, mock_destroy, client):
     mock_get.return_value = test_offer_1
     response = client.delete('/offer/{}'.format(
@@ -78,14 +78,14 @@ def test_delete_offer(mock_get, mock_destroy, client):
     assert mock_destroy.call_count == 1
 
 
-@mock.patch('flocx_market.db.sqlalchemy.api.offer_get')
+@mock.patch('flocx_market.objects.offer.Offer.get')
 def test_delete_offer_missing(mock_get, client):
     mock_get.return_value = None
     response = client.delete('/offer/does-not-exist')
     assert response.status_code == 404
 
 
-@mock.patch('flocx_market.db.sqlalchemy.api.offer_create')
+@mock.patch('flocx_market.objects.offer.Offer.create')
 def test_create_offer(mock_create, client):
     mock_create.return_value = test_offer_1
     res = client.post('/offer', data=json.dumps(test_offer_1.to_dict()))
@@ -94,23 +94,22 @@ def test_create_offer(mock_create, client):
     assert res.json == test_offer_1.to_dict()
 
 
-@mock.patch('flocx_market.db.sqlalchemy.api.offer_update')
-@mock.patch('flocx_market.db.sqlalchemy.api.offer_get')
-def test_update_offer(mock_get, mock_update, client):
+@mock.patch('flocx_market.objects.offer.Offer.save')
+@mock.patch('flocx_market.objects.offer.Offer.get')
+def test_update_offer(mock_get, mock_save, client):
     mock_get.return_value = test_offer_1
-    mock_update.return_value = test_offer_1
+    mock_save.return_value = test_offer_1
     res = client.put('/offer/{}'.format(test_offer_1.marketplace_offer_id),
                      data=json.dumps(dict(status='testing')))
     assert res.status_code == 200
-    assert mock_update.call_count == 1
-    assert res.json['status'] == 'testing'
+    assert mock_save.call_count == 1
 
 
-@mock.patch('flocx_market.db.sqlalchemy.api.offer_update')
-@mock.patch('flocx_market.db.sqlalchemy.api.offer_get')
-def test_update_offer_missing(mock_get, mock_update, client):
+@mock.patch('flocx_market.objects.offer.Offer.save')
+@mock.patch('flocx_market.objects.offer.Offer.get')
+def test_update_offer_missing(mock_get, mock_save, client):
     mock_get.return_value = None
     res = client.put('/offer/does-not-exist',
                      data=json.dumps(dict(status='testing')))
     assert res.status_code == 404
-    assert mock_update.call_count == 0
+    assert mock_save.call_count == 0

--- a/flocx_market/tests/unit/objects/test_object_bid.py
+++ b/flocx_market/tests/unit/objects/test_object_bid.py
@@ -29,12 +29,14 @@ test_bid_2 = dict(marketplace_bid_id="1232",
 
 @mock.patch('flocx_market.db.sqlalchemy.api.bid_create')
 def test_create(bid_create):
+    bid_create.return_value = test_bid_1
     bid.Bid.create(test_bid_1)
     bid_create.assert_called_once()
 
 
 @mock.patch('flocx_market.db.sqlalchemy.api.bid_get')
 def test_get(bid_get):
+    bid_get.return_value = test_bid_2
     b = bid.Bid(**test_bid_2)
     bid.Bid.get(b.marketplace_bid_id)
     bid_get.assert_called_once()
@@ -60,7 +62,8 @@ def test_destroy(bid_destroy):
 
 @mock.patch('flocx_market.db.sqlalchemy.api.bid_update')
 def test_save(bid_update):
+    bid_update.return_value = test_bid_1
     b = bid.Bid(**test_bid_1)
-    test_bid_1['status'] = "busy"
-    b.save(test_bid_1)
+    b.status = "busy"
+    b.save()
     bid_update.assert_called_once()

--- a/flocx_market/tests/unit/objects/test_object_offer.py
+++ b/flocx_market/tests/unit/objects/test_object_offer.py
@@ -33,12 +33,14 @@ test_offer_2 = dict(
 
 @mock.patch('flocx_market.db.sqlalchemy.api.offer_create')
 def test_create(offer_create):
+    offer_create.return_value = test_offer_1
     offer.Offer.create(test_offer_1)
     offer_create.assert_called_once()
 
 
 @mock.patch('flocx_market.db.sqlalchemy.api.offer_get')
 def test_get(offer_get):
+    offer_get.return_value = test_offer_1
     o = offer.Offer(**test_offer_1)
     offer.Offer.get(o.marketplace_offer_id)
     offer_get.assert_called_once()
@@ -64,7 +66,8 @@ def test_destroy(offer_destroy):
 
 @mock.patch('flocx_market.db.sqlalchemy.api.offer_update')
 def test_save(offer_update):
+    offer_update.return_value = test_offer_1
     o = offer.Offer(**test_offer_1)
-    test_offer_1['status'] = "busy"
-    o.save(test_offer_1)
+    o.status = "busy"
+    o.save()
     offer_update.assert_called_once()


### PR DESCRIPTION
By using oslo versioned object code, we can call save without passing
in a dict. Instead, we can just modify the object fields before
calling save().

Addresses #89