### PR TITLE
Skip dotfiles when checking for conflict markers

### DIFF
--- a/scripts/check-conflict-markers.sh
+++ b/scripts/check-conflict-markers.sh
@@ -5,7 +5,7 @@ TOP=$(git rev-parse --show-toplevel)
 
 prepare_files_for_testing "check for conflict markers"
 
-if find . -name .tox -prune -o -type f -print0 |
+if find . -name '.*' -prune -o -type f -print0 |
 	xargs -0 grep -Hn -E '^(<{7}|>{7}|={7})( |$)'; then
 
 	echo "ERROR: found conflict markers" >&2


### PR DESCRIPTION
The conflict marker check was too enthusiastic and was checking files
in the `.eggs` directory and elsewhere, which could cause erroneous
test failures.  This commit prevents the check from looking at files
in directories with a leading `.` (like `.tox`, `.eggs`, etc).

Closes #91