### PR TITLE
Scoping bids, contracts, and offer_contract obj

### DIFF
--- a/flocx_market/api/bid.py
+++ b/flocx_market/api/bid.py
@@ -28,7 +28,7 @@ class Bid(Resource):
         b = bid.Bid.get(marketplace_bid_id, g.context)
         if b is None:
             return {'message': 'Bid not found.'}, 404
-        b.destroy()
+        b.destroy(g.context)
         return {'message': 'Bid deleted.'}
 
     @classmethod
@@ -41,5 +41,5 @@ class Bid(Resource):
         # we only allow status field to be modified
         if 'status' in data:
             b.status = data['status']
-            return b.save().to_dict()
+            return b.save(g.context).to_dict()
         return b.to_dict()

--- a/flocx_market/api/contract.py
+++ b/flocx_market/api/contract.py
@@ -29,7 +29,7 @@ class Contract(Resource):
 
         if c is None:
             return {'message': 'Contract not found.'}, 404
-        c.destroy()
+        c.destroy(g.context)
         return {'message': 'Contract deleted.'}
 
     @classmethod
@@ -43,5 +43,5 @@ class Contract(Resource):
         # we only allow status field to be modified
         if 'status' in data:
             c.status = data['status']
-            return c.save().to_dict()
+            return c.save(g.context).to_dict()
         return c.to_dict()

--- a/flocx_market/db/sqlalchemy/api.py
+++ b/flocx_market/db/sqlalchemy/api.py
@@ -44,15 +44,13 @@ def offer_get(marketplace_offer_id, context):
             marketplace_offer_id=marketplace_offer_id).first()
 
 
-def offer_get_all_by_project_id(context):
+def offer_get_all(context):
+    return get_session().query(models.Offer).all()
 
+
+def offer_get_all_by_project_id(context):
     return get_session().query(models.Offer).filter_by(
         project_id=context.project_id).all()
-
-
-def offer_get_all(context):
-
-    return get_session().query(models.Offer).all()
 
 
 def offer_get_all_unexpired(context):
@@ -78,7 +76,8 @@ def offer_create(values, context):
 def offer_update(marketplace_offer_id, values, context):
 
     if context.is_admin:
-        offer_ref = offer_get(marketplace_offer_id, context)
+        offer_ref = get_session().query(models.Offer).filter_by(
+                    marketplace_offer_id=marketplace_offer_id).first()
     else:
         offer_ref = get_session().query(models.Offer).filter_by(
             marketplace_offer_id=marketplace_offer_id,
@@ -95,7 +94,8 @@ def offer_update(marketplace_offer_id, values, context):
 
 def offer_destroy(marketplace_offer_id, context):
     if context.is_admin:
-        offer_ref = offer_get(marketplace_offer_id, context)
+        offer_ref = get_session().query(models.Offer).filter_by(
+                    marketplace_offer_id=marketplace_offer_id).first()
     else:
         offer_ref = get_session().query(models.Offer).filter_by(
             marketplace_offer_id=marketplace_offer_id,
@@ -110,6 +110,8 @@ def offer_destroy(marketplace_offer_id, context):
             get_session().query(models.Offer).filter_by(
                 marketplace_offer_id=marketplace_offer_id,
                 project_id=context.project_id).delete()
+    else:
+        return None
 
 
 def bid_get(marketplace_bid_id, context):
@@ -117,17 +119,23 @@ def bid_get(marketplace_bid_id, context):
         marketplace_bid_id=marketplace_bid_id).first()
 
 
+def bid_get_all(context):
+    return get_session().query(models.Bid).all()
+
+
+def bid_get_all_by_project_id(context):
+    return get_session().query(models.Bid)\
+        .filter_by(project_id=context.project_id).all()
+
+
 def bid_get_all_unexpired(context):
     return get_session().query(models.Bid)\
         .filter(models.Bid.status != 'expired').all()
 
 
-def bid_get_all(context):
-    return get_session().query(models.Bid).all()
-
-
 def bid_create(values, context):
     values['marketplace_bid_id'] = uuidutils.generate_uuid()
+    values['project_id'] = context.project_id
     bid_ref = models.Bid()
     bid_ref.update(values)
     bid_ref.save(get_session())
@@ -135,18 +143,43 @@ def bid_create(values, context):
 
 
 def bid_update(marketplace_bid_id, values, context):
-    bid_ref = bid_get(marketplace_bid_id, context)
-    values.pop('marketplace_bid_id', None)
-    bid_ref.update(values)
-    bid_ref.save(get_session())
-    return bid_ref
+    if context.is_admin:
+        bid_ref = get_session().query(models.Bid).filter_by(
+                    marketplace_bid_id=marketplace_bid_id).first()
+    else:
+        bid_ref = get_session().query(models.Bid).filter_by(
+            marketplace_bid_id=marketplace_bid_id,
+            project_id=context.project_id).first()
+
+    if bid_ref:
+        values.pop('marketplace_bid_id', None)
+        bid_ref.update(values)
+        bid_ref.save(get_session())
+        return bid_ref
+    else:
+        return None
 
 
 def bid_destroy(marketplace_bid_id, context):
-    bid_ref = bid_get(marketplace_bid_id, context)
+    if context.is_admin:
+        bid_ref = get_session().query(models.Bid).filter_by(
+                    marketplace_bid_id=marketplace_bid_id).first()
+    else:
+        bid_ref = get_session().query(models.Bid).filter_by(
+            marketplace_bid_id=marketplace_bid_id,
+            project_id=context.project_id).first()
+
     if bid_ref:
-        get_session().query(models.Bid).filter_by(
-            marketplace_bid_id=marketplace_bid_id).delete()
+
+        if context.is_admin:
+            get_session().query(models.Bid).filter_by(
+                marketplace_bid_id=marketplace_bid_id).delete()
+        else:
+            get_session().query(models.Bid).filter_by(
+                marketplace_bid_id=marketplace_bid_id,
+                project_id=context.project_id).delete()
+    else:
+        return None
 
 
 # contract
@@ -165,42 +198,60 @@ def contract_get_all_unexpired(context):
 
 
 def contract_create(values, context):
-    values['contract_id'] = uuidutils.generate_uuid()
-    # exception for foreign key constraint needed here
-    offers = values['offers']
 
-    del values['offers']
-    contract_ref = models.Contract()
-    contract_ref.update(values)
-    contract_ref.save(get_session())
+    if context.is_admin:
+        values['contract_id'] = uuidutils.generate_uuid()
+        # exception for foreign key constraint needed here
+        offers = values['offers']
 
-    # update foreign key for offers
-    for offer_id in offers:
-        ocr_data = dict(contract_id=values['contract_id'],
-                        marketplace_offer_id=offer_id,
-                        status='unretrieved')
-        offer_contract_relationship_create(ocr_data)
-    return contract_ref
+        del values['offers']
+        contract_ref = models.Contract()
+        contract_ref.update(values)
+        contract_ref.save(get_session())
+
+        # update foreign key for offers
+        for offer_id in offers:
+            ocr_data = dict(contract_id=values['contract_id'],
+                            marketplace_offer_id=offer_id,
+                            status='unretrieved')
+            offer_contract_relationship_create(context, ocr_data)
+        return contract_ref
+    else:
+        return None
 
 
 def contract_update(contract_id, values, context):
-    contract_ref = contract_get(contract_id, context)
-    values.pop('contract_id', None)
-    contract_ref.update(values)
-    contract_ref.save(get_session())
-    return contract_ref
+
+    if context.is_admin:
+        contract_ref = get_session().query(models.Contract).filter_by(
+                        contract_id=contract_id).first()
+        if contract_ref:
+            values.pop('contract_id', None)
+            contract_ref.update(values)
+            contract_ref.save(get_session())
+            return contract_ref
+        else:
+            return None
+    else:
+        return None
 
 
 def contract_destroy(contract_id, context):
-    contract_ref = contract_get(contract_id, context)
-    if contract_ref:
-        get_session().query(models.Contract).filter_by(
-            contract_id=contract_id).delete()
+    if context.is_admin:
+        contract_ref = contract_get(contract_id, context)
+        if contract_ref:
+            get_session().query(models.Contract).filter_by(
+                contract_id=contract_id).delete()
+        else:
+            return None
+    else:
+        return None
 
 
 # offer_contract_relationship
-def offer_contract_relationship_get(marketplace_offer_id=None,
-                                    contract_id=None):
+def offer_contract_relationship_get(context,
+                                    contract_id=None,
+                                    marketplace_offer_id=None):
 
     if (contract_id is not None) and (marketplace_offer_id is None):
         return get_session().query(models.OfferContractRelationship).filter_by(
@@ -212,49 +263,68 @@ def offer_contract_relationship_get(marketplace_offer_id=None,
     elif (contract_id is not None) and (marketplace_offer_id is not None):
         return get_session().query(models.OfferContractRelationship) \
             .filter(models.OfferContractRelationship.contract_id
-                    == contract_id and
+                    == contract_id,
                     models.OfferContractRelationship.marketplace_offer_id
                     == marketplace_offer_id).first()
 
 
-def offer_contract_relationship_get_all():
+def offer_contract_relationship_get_all(context):
     return get_session().query(models.OfferContractRelationship).all()
 
 
-def offer_contract_relationship_get_all_unexpired():
+def offer_contract_relationship_get_all_unexpired(context):
     return get_session().query(models.OfferContractRelationship)\
         .filter(models.OfferContractRelationship.status != 'expired').all()
 
 
-def offer_contract_relationship_create(values):
-    values['offer_contract_relationship_id'] = uuidutils.generate_uuid()
-    # exception for foreign key constraint needed here
-    offer_contract_relationship_ref = models.OfferContractRelationship()
-    offer_contract_relationship_ref.update(values)
-    offer_contract_relationship_ref.save(get_session())
-    return offer_contract_relationship_ref
+def offer_contract_relationship_create(context, values):
+
+    if context.is_admin:
+        values['offer_contract_relationship_id'] = uuidutils.generate_uuid()
+        # exception for foreign key constraint needed here
+        offer_contract_relationship_ref = models.OfferContractRelationship()
+        offer_contract_relationship_ref.update(values)
+        offer_contract_relationship_ref.save(get_session())
+        return offer_contract_relationship_ref
+    else:
+        return None
 
 
-def offer_contract_relationship_update(contract_id,
-                                       marketplace_offer_id, values):
-    offer_contract_relationship_ref = offer_contract_relationship_get(
-        contract_id, marketplace_offer_id)
+def offer_contract_relationship_update(context,
+                                       contract_id,
+                                       marketplace_offer_id,
+                                       values):
+    if context.is_admin:
+        offer_contract_relationship_ref = offer_contract_relationship_get(
+            context,
+            contract_id=contract_id,
+            marketplace_offer_id=marketplace_offer_id)
 
-    values.pop('contract_id', None)
-    values.pop('marketplace_offer_id', None)
-    offer_contract_relationship_ref.update(values)
-    offer_contract_relationship_ref.save(get_session())
-    return offer_contract_relationship_ref
+        values.pop('contract_id', None)
+        values.pop('marketplace_offer_id', None)
+        offer_contract_relationship_ref.update(values)
+        offer_contract_relationship_ref.save(get_session())
+        return offer_contract_relationship_ref
+    else:
+        return None
 
 
-def offer_contract_relationship_destroy(contract_id,
+def offer_contract_relationship_destroy(context,
+                                        contract_id,
                                         marketplace_offer_id):
-    offer_contract_relationship_ref = offer_contract_relationship_get(
-        contract_id, marketplace_offer_id)
+    if context.is_admin:
+        offer_contract_relationship_ref = offer_contract_relationship_get(
+                                            context,
+                                            contract_id,
+                                            marketplace_offer_id)
 
-    if offer_contract_relationship_ref:
-        get_session().query(models.OfferContractRelationship) \
-            .filter(models.OfferContractRelationship.contract_id
-                    == contract_id and
-                    models.OfferContractRelationship.marketplace_offer_id
-                    == marketplace_offer_id).delete()
+        if offer_contract_relationship_ref:
+            get_session().query(models.OfferContractRelationship) \
+                .filter(models.OfferContractRelationship.contract_id
+                        == contract_id and
+                        models.OfferContractRelationship.marketplace_offer_id
+                        == marketplace_offer_id).delete()
+        else:
+            return None
+    else:
+        return None

--- a/flocx_market/objects/bid.py
+++ b/flocx_market/objects/bid.py
@@ -57,6 +57,11 @@ class Bid(base.FLOCXMarketObject):
         unexpired = db.bid_get_all_unexpired(context)
         return cls._from_db_object_list(unexpired)
 
+    @classmethod
+    def get_all_by_project_id(cls, context):
+        by_project_id = db.bid_get_all_by_project_id(context)
+        return cls._from_db_object_list(by_project_id)
+
     def expire(self, context):
         self.status = 'expired'
         self.save(context)

--- a/flocx_market/objects/offer.py
+++ b/flocx_market/objects/offer.py
@@ -58,6 +58,11 @@ class Offer(base.FLOCXMarketObject):
         unexpired = db.offer_get_all_unexpired(context)
         return cls._from_db_object_list(unexpired)
 
+    @classmethod
+    def get_all_by_project_id(cls, context):
+        by_project_id = db.offer_get_all_by_project_id(context)
+        return cls._from_db_object_list(by_project_id)
+
     def expire(self, context):
         self.status = 'expired'
         self.save(context)

--- a/flocx_market/objects/offer_contract_relationship.py
+++ b/flocx_market/objects/offer_contract_relationship.py
@@ -16,38 +16,46 @@ class OfferContractRelationship(base.FLOCXMarketObject):
     }
 
     @classmethod
-    def get(cls, marketplace_offer_id, contract_id):
+    def get(cls, context, contract_id, marketplace_offer_id):
         if (contract_id is None) and (marketplace_offer_id is None):
             return None
         else:
-            o = db.offer_contract_relationship_get(contract_id,
-                                                   marketplace_offer_id)
+            o = db.offer_contract_relationship_get(
+                contract_id=contract_id,
+                marketplace_offer_id=marketplace_offer_id,
+                context=context)
             if o is None:
                 return None
             else:
                 return cls._from_db_object(cls(), o)
 
-    def destroy(self):
-        db.offer_contract_relationship_destroy(self.contract_id,
-                                               self.marketplace_offer_id)
+    def destroy(self, context):
+        db.offer_contract_relationship_destroy(
+            contract_id=self.contract_id,
+            marketplace_offer_id=self.marketplace_offer_id,
+            context=context)
         return True
 
     @classmethod
-    def get_all(cls):
-        all_ocrs = db.offer_contract_relationship_get_all()
+    def get_all(cls, context):
+        all_ocrs = db.offer_contract_relationship_get_all(context)
         return cls._from_db_object_list(all_ocrs)
 
-    def save(self):
+    def save(self, context):
         updates = self.obj_get_changes()
         db_offer_contract_relationship = db.offer_contract_relationship_update(
-            self.contract_id, self.marketplace_offer_id, updates)
+            context,
+            self.contract_id,
+            self.marketplace_offer_id,
+            updates,
+            )
         return self._from_db_object(self, db_offer_contract_relationship)
 
     @classmethod
-    def get_all_unexpired(cls):
-        unexpired = db.offer_contract_relationship_get_all_unexpired()
+    def get_all_unexpired(cls, context):
+        unexpired = db.offer_contract_relationship_get_all_unexpired(context)
         return cls._from_db_object_list(unexpired)
 
-    def expire(self):
+    def expire(self, context):
         self.status = 'expired'
-        self.save()
+        self.save(context)

--- a/flocx_market/tests/unit/api/test_app_offer_contract_relationship.py
+++ b/flocx_market/tests/unit/api/test_app_offer_contract_relationship.py
@@ -128,7 +128,7 @@ def test_get_offer_contract_relationship(mock_get, client):
         test_ocr_1.marketplace_offer_id, test_ocr_1.contract_id))
     print(response.data)
     assert response.status_code == 200
-    mock_get.assert_called_with('test_offer_1', 'test_contract_1')
+    mock_get.assert_called_once()
     assert response.json['offer_contract_relationship_id'] == 'test_ocr_id_1'
 
 

--- a/flocx_market/tests/unit/objects/test_object_bid.py
+++ b/flocx_market/tests/unit/objects/test_object_bid.py
@@ -58,6 +58,12 @@ def test_get_all(bid_get_all):
     bid_get_all.assert_called_once()
 
 
+@mock.patch('flocx_market.db.sqlalchemy.api.bid_get_all_by_project_id')
+def test_get_all_by_project_id(bid_get_all):
+    bid.Bid.get_all_by_project_id(scoped_context)
+    bid_get_all.assert_called_once()
+
+
 @mock.patch('flocx_market.db.sqlalchemy.api.bid_destroy')
 def test_destroy(bid_destroy):
     b = bid.Bid(**test_bid_1)

--- a/flocx_market/tests/unit/objects/test_object_offer.py
+++ b/flocx_market/tests/unit/objects/test_object_offer.py
@@ -19,7 +19,7 @@ test_offer_1 = dict(
     server_config={'foo': 'bar'},
     cost=0.0,
     contract_id=None,
-    project_id='5599'
+    project_id=5599
 )
 
 test_offer_2 = dict(
@@ -34,7 +34,7 @@ test_offer_2 = dict(
     server_config={'foo': 'bar'},
     cost=0.0,
     contract_id=None,
-    project_id='5599'
+    project_id=5599
 )
 
 scoped_context = ctx.RequestContext(is_admin=False,
@@ -64,6 +64,12 @@ def test_get_none():
 @mock.patch('flocx_market.db.sqlalchemy.api.offer_get_all')
 def test_get_all(offer_get_all):
     offer.Offer.get_all(scoped_context)
+    offer_get_all.assert_called_once()
+
+
+@mock.patch('flocx_market.db.sqlalchemy.api.offer_get_all_by_project_id')
+def test_get_all_by_project_id(offer_get_all):
+    offer.Offer.get_all_by_project_id(scoped_context)
     offer_get_all.assert_called_once()
 
 

--- a/flocx_market/tests/unit/objects/test_object_offer_contract_relationship.py
+++ b/flocx_market/tests/unit/objects/test_object_offer_contract_relationship.py
@@ -1,5 +1,6 @@
 from flocx_market.objects import offer_contract_relationship as ocr
 import unittest.mock as mock
+from oslo_context import context as ctx
 
 test_ocr_dict = dict(
     offer_contract_relationship_id='test_offer_contract_relationship_id',
@@ -7,24 +8,29 @@ test_ocr_dict = dict(
     marketplace_offer_id='test_offer_1',
     status='unretrieved')
 
+scoped_context = ctx.RequestContext(is_admin=False,
+                                    project_id='5599')
+
 
 @mock.patch('flocx_market.db.sqlalchemy.api.offer_contract_relationship_get')
 def test_get(offer_contract_relationship_get):
     offer_contract_relationship_get.return_value = test_ocr_dict
     oc = ocr.OfferContractRelationship(**test_ocr_dict)
-    ocr.OfferContractRelationship.get(oc.contract_id, oc.marketplace_offer_id)
+    ocr.OfferContractRelationship.get(oc.contract_id,
+                                      oc.marketplace_offer_id,
+                                      scoped_context)
     offer_contract_relationship_get.assert_called_once()
 
 
 def test_get_none():
-    ret = ocr.OfferContractRelationship.get(None, None)
+    ret = ocr.OfferContractRelationship.get(scoped_context, None, None)
     assert ret is None
 
 
 @mock.patch(
     'flocx_market.db.sqlalchemy.api.offer_contract_relationship_get_all')
 def test_get_all(offer_contract_relationship_get_all):
-    ocr.OfferContractRelationship.get_all()
+    ocr.OfferContractRelationship.get_all(scoped_context)
     offer_contract_relationship_get_all.assert_called_once()
 
 
@@ -32,7 +38,7 @@ def test_get_all(offer_contract_relationship_get_all):
     'flocx_market.db.sqlalchemy.api.offer_contract_relationship_destroy')
 def test_destroy(offer_contract_relationship_destroy):
     oc = ocr.OfferContractRelationship(**test_ocr_dict)
-    oc.destroy()
+    oc.destroy(scoped_context)
     offer_contract_relationship_destroy.assert_called_once()
 
 
@@ -42,7 +48,7 @@ def test_save(offer_contract_relationship_update):
     offer_contract_relationship_update.return_value = test_ocr_dict
     oc = ocr.OfferContractRelationship(**test_ocr_dict)
     oc.status = "retrieved"
-    oc.save()
+    oc.save(scoped_context)
     offer_contract_relationship_update.assert_called_once()
 
 
@@ -53,7 +59,7 @@ def test_save(offer_contract_relationship_update):
     'flocx_market.objects.offer_contract_relationship.db'
     '.offer_contract_relationship_get_all_unexpired')
 def test_update_to_expire(get_all, _from_db_object_list):
-    ocr.OfferContractRelationship.get_all_unexpired()
+    ocr.OfferContractRelationship.get_all_unexpired(scoped_context)
     get_all.assert_called_once()
 
 
@@ -61,6 +67,6 @@ def test_update_to_expire(get_all, _from_db_object_list):
             '.OfferContractRelationship.save')
 def test_expire(save):
     oc = ocr.OfferContractRelationship(**test_ocr_dict)
-    oc.expire()
+    oc.expire(scoped_context)
 
     save.assert_called_once()


### PR DESCRIPTION
Uses oslo_context to scope queries to the bids,
contracts, and offer_contract relationship objects. Updated and added
new tests to accomodate these changes. TG-163