### PR TITLE
Updated db models to use TimestampMixin and standardize on project_id

### DIFF
--- a/flocx_market/db/sqlalchemy/api.py
+++ b/flocx_market/db/sqlalchemy/api.py
@@ -66,7 +66,6 @@ def offer_get_all_unexpired(context):
 
 def offer_create(values, context):
     values['marketplace_offer_id'] = uuidutils.generate_uuid()
-    values['project_id'] = context.project_id
     offer_ref = models.Offer()
     offer_ref.update(values)
     offer_ref.save(get_session())

--- a/flocx_market/db/sqlalchemy/models.py
+++ b/flocx_market/db/sqlalchemy/models.py
@@ -6,7 +6,7 @@ import datetime
 from flocx_market.db.orm import orm
 
 
-class FLOCXMarketBase(models.ModelBase):
+class FLOCXMarketBase(models.TimestampMixin, models.ModelBase):
     metadata = None
 
     def to_dict(self):
@@ -30,7 +30,7 @@ class Bid(Base):
         primary_key=True,
         autoincrement=False,
     )
-    creator_bid_id = orm.Column(orm.String(64), nullable=False)
+    project_id = orm.Column(orm.String(64), nullable=False)
     server_quantity = orm.Column(orm.Integer, nullable=False)
     start_time = orm.Column(orm.DateTime(timezone=True), nullable=False)
     end_time = orm.Column(orm.DateTime(timezone=True), nullable=False)
@@ -41,7 +41,6 @@ class Bid(Base):
         enforce_unicode=False), nullable=False)
     cost = orm.Column(orm.Float, nullable=False)
     contracts = orm.relationship('Contract', lazy='dynamic')
-    project_id = orm.Column(orm.String(64), nullable=False)
 
 
 class Offer(Base):
@@ -56,13 +55,11 @@ class Offer(Base):
         nullable=False,
         unique=True,
     )
-    provider_id = orm.Column(orm.String(64), nullable=False)
-    marketplace_date_created = orm.Column(orm.DateTime(timezone=True),
-                                          nullable=False)
+    project_id = orm.Column(orm.String(64), nullable=False)
     status = orm.Column(orm.String(15), nullable=False, default="available")
     server_id = orm.Column(orm.String(64), nullable=False, unique=True)
     start_time = orm.Column(orm.DateTime(timezone=True), nullable=False)
-    end_time = orm.Column(orm.DateTime(timezone=True), nullable=False)
+    end_time = orm.Column(orm.DateTime(timezone=True), nullable=True)
     server_config = orm.Column(
         sqlalchemy_jsonfield.JSONField(enforce_string=True,
                                        enforce_unicode=False),
@@ -71,7 +68,6 @@ class Offer(Base):
     cost = orm.Column(orm.Float, nullable=False)
     offer_contract_relationships = orm.relationship(
         'OfferContractRelationship', lazy='dynamic')
-    project_id = orm.Column(orm.String(64), nullable=False)
 
 
 class Contract(Base):
@@ -81,7 +77,6 @@ class Contract(Base):
         primary_key=True,
         autoincrement=False,
     )
-    time_created = orm.Column(orm.DateTime(timezone=True), nullable=False)
     status = orm.Column(orm.String(15), nullable=False, default='unretrieved')
     start_time = orm.Column(orm.DateTime(timezone=True), nullable=False)
     end_time = orm.Column(orm.DateTime(timezone=True), nullable=False)

--- a/flocx_market/objects/base.py
+++ b/flocx_market/objects/base.py
@@ -2,6 +2,8 @@ from oslo_log import log
 from oslo_versionedobjects import base as object_base
 import datetime
 
+from flocx_market.objects import fields
+
 
 LOG = log.getLogger(__name__)
 
@@ -10,6 +12,11 @@ class FLOCXMarketObject(object_base.VersionedObject):
 
     OBJ_SERIAL_NAMESPACE = 'flocx_market_object'
     OBJ_PROJECT_NAMESPACE = 'flocx_market'
+
+    fields = {
+        'created_at': fields.DateTimeField(nullable=True),
+        'updated_at': fields.DateTimeField(nullable=True),
+    }
 
     @staticmethod
     def _from_db_object(obj, db_obj):

--- a/flocx_market/objects/bid.py
+++ b/flocx_market/objects/bid.py
@@ -10,7 +10,7 @@ class Bid(base.FLOCXMarketObject):
 
     fields = {
         'marketplace_bid_id': fields.StringField(),
-        'creator_bid_id': fields.StringField(),
+        'project_id': fields.StringField(),
         'server_quantity': fields.IntegerField(),
         'start_time': fields.DateTimeField(nullable=True),
         'end_time': fields.DateTimeField(nullable=True),
@@ -18,7 +18,6 @@ class Bid(base.FLOCXMarketObject):
         'status': fields.StringField(),
         'server_config_query': fields.FlexibleDictField(nullable=True),
         'cost': fields.FloatField(),
-        'project_id': fields.StringField()
     }
 
     @classmethod

--- a/flocx_market/objects/contract.py
+++ b/flocx_market/objects/contract.py
@@ -10,7 +10,6 @@ class Contract(base.FLOCXMarketObject):
 
     fields = {
         'contract_id': fields.StringField(),
-        'time_created': fields.DateTimeField(nullable=True),
         'status': fields.StringField(),
         'start_time': fields.DateTimeField(nullable=True),
         'end_time': fields.DateTimeField(nullable=True),

--- a/flocx_market/objects/offer.py
+++ b/flocx_market/objects/offer.py
@@ -11,15 +11,13 @@ class Offer(base.FLOCXMarketObject):
     fields = {
         'marketplace_offer_id': fields.StringField(),
         'provider_offer_id': fields.StringField(),
-        'provider_id': fields.StringField(),
-        'marketplace_date_created': fields.DateTimeField(nullable=True),
+        'project_id': fields.StringField(),
         'status': fields.StringField(),
         'server_id': fields.StringField(),
         'start_time': fields.DateTimeField(nullable=True),
         'end_time': fields.DateTimeField(nullable=True),
         'server_config': fields.FlexibleDictField(nullable=True),
         'cost': fields.FloatField(),
-        'project_id': fields.StringField()
     }
 
     @classmethod

--- a/flocx_market/tests/unit/api/test_app_bid.py
+++ b/flocx_market/tests/unit/api/test_app_bid.py
@@ -11,27 +11,35 @@ CONF = flocx_market.conf.CONF
 now = datetime.datetime.utcnow()
 
 
-test_bid_1 = bid.Bid(marketplace_bid_id='test_bid_1',
-                     creator_bid_id="1234",
-                     server_quantity=2,
-                     start_time=now,
-                     end_time=now,
-                     duration=16400,
-                     status="available",
-                     server_config_query={'foo': 'bar'},
-                     cost=11.5,
-                     project_id='5599')
+test_bid_1 = bid.Bid(
+    marketplace_bid_id='test_bid_1',
+    creator_bid_id="1234",
+    server_quantity=2,
+    start_time=now,
+    end_time=now,
+    duration=16400,
+    status="available",
+    server_config_query={'foo': 'bar'},
+    cost=11.5,
+    project_id='5599',
+    created_at=now,
+    updated_at=now,
+)
 
-test_bid_2 = bid.Bid(marketplace_bid_id='test_bid_2',
-                     creator_bid_id="2345",
-                     server_quantity=2,
-                     start_time=now,
-                     end_time=now,
-                     duration=16400,
-                     status="available",
-                     server_config_query={'foo': 'bar'},
-                     cost=11.5,
-                     project_id='5599')
+test_bid_2 = bid.Bid(
+    marketplace_bid_id='test_bid_2',
+    creator_bid_id="2345",
+    server_quantity=2,
+    start_time=now,
+    end_time=now,
+    duration=16400,
+    status="available",
+    server_config_query={'foo': 'bar'},
+    cost=11.5,
+    project_id='5599',
+    created_at=now,
+    updated_at=now,
+)
 
 scoped_context = ctx.RequestContext(is_admin=False,
                                     project_id='5599')

--- a/flocx_market/tests/unit/api/test_app_contract.py
+++ b/flocx_market/tests/unit/api/test_app_contract.py
@@ -10,7 +10,6 @@ CONF = flocx_market.conf.CONF
 now = datetime.datetime.utcnow()
 
 contract_1_bid = bid.Bid(marketplace_bid_id='test_bid_1',
-                         creator_bid_id="1234",
                          server_quantity=2,
                          start_time=now,
                          end_time=now,
@@ -18,11 +17,12 @@ contract_1_bid = bid.Bid(marketplace_bid_id='test_bid_1',
                          status="available",
                          server_config_query={'foo': 'bar'},
                          cost=11.5,
-                         project_id='5599'
+                         project_id='5599',
+                         created_at=now,
+                         updated_at=now,
                          )
 
 contract_2_bid = bid.Bid(marketplace_bid_id='test_bid_2',
-                         creator_bid_id="2345",
                          server_quantity=2,
                          start_time=now,
                          end_time=now,
@@ -30,12 +30,12 @@ contract_2_bid = bid.Bid(marketplace_bid_id='test_bid_2',
                          status="available",
                          server_config_query={'foo': 'bar'},
                          cost=11.5,
-                         project_id='5599'
+                         project_id='5599',
+                         created_at=now,
+                         updated_at=now,
                          )
 
-contract_1_offer = offer.Offer(marketplace_date_created=now,
-                               marketplace_offer_id='test_offer_1',
-                               provider_id='1234',
+contract_1_offer = offer.Offer(marketplace_offer_id='test_offer_1',
                                server_id='3456',
                                start_time=now,
                                end_time=now,
@@ -43,12 +43,12 @@ contract_1_offer = offer.Offer(marketplace_date_created=now,
                                server_config={'bar': 'foo'},
                                cost=0.0,
                                contract_id='test_contract_1',
-                               project_id='5599'
+                               project_id='5599',
+                               created_at=now,
+                               updated_at=now,
                                )
 
 contract_2_offer = offer.Offer(marketplace_offer_id='test_offer_2',
-                               marketplace_date_created=now,
-                               provider_id='2345',
                                server_id='4567',
                                start_time=now,
                                end_time=now,
@@ -56,8 +56,9 @@ contract_2_offer = offer.Offer(marketplace_offer_id='test_offer_2',
                                server_config={'foo': 'bar'},
                                cost=0.0,
                                contract_id='test_contract_2',
-                               project_id='5599'
-
+                               project_id='5599',
+                               created_at=now,
+                               updated_at=now,
                                )
 
 test_contract_1 = contract.Contract(contract_id='test_contract_1',
@@ -68,7 +69,9 @@ test_contract_1 = contract.Contract(contract_id='test_contract_1',
                                     cost=0.0,
                                     bid_id=contract_1_bid.marketplace_bid_id,
                                     bid=None,
-                                    project_id='5599'
+                                    project_id='5599',
+                                    created_at=now,
+                                    updated_at=now,
                                     )
 
 test_contract_2 = contract.Contract(contract_id='test_contract_2',
@@ -79,7 +82,9 @@ test_contract_2 = contract.Contract(contract_id='test_contract_2',
                                     cost=0.0,
                                     bid_id=contract_2_bid.marketplace_bid_id,
                                     bid=None,
-                                    project_id='5599'
+                                    project_id='5599',
+                                    created_at=now,
+                                    updated_at=now,
                                     )
 
 test_contract_dict = dict(contract_id='test_contract_2',
@@ -90,7 +95,9 @@ test_contract_dict = dict(contract_id='test_contract_2',
                           cost=0.0,
                           bid_id='test_bid_2',
                           offers=[contract_1_offer.marketplace_offer_id],
-                          project_id='5599'
+                          project_id='5599',
+                          created_at="2016-07-16T19:20:30",
+                          updated_at="2016-07-16T19:20:30",
                           )
 
 scoped_context = ctx.RequestContext(is_admin=False,

--- a/flocx_market/tests/unit/api/test_app_offer.py
+++ b/flocx_market/tests/unit/api/test_app_offer.py
@@ -16,10 +16,8 @@ now = datetime.datetime.utcnow()
 
 
 test_offer_1 = offer.Offer(
-    marketplace_date_created=now,
     provider_offer_id='a41fadc1-6ae9-47e5-a74e-2dcf2b4dd55a',
     marketplace_offer_id='test_offer_1',
-    provider_id='1234',
     server_id='3456',
     start_time=now,
     end_time=now,
@@ -27,14 +25,14 @@ test_offer_1 = offer.Offer(
     server_config={'bar': 'foo'},
     cost=0.0,
     contract_id=None,
-    project_id='5599'
+    project_id='5599',
+    created_at=now,
+    updated_at=now,
 )
 
 test_offer_2 = offer.Offer(
     marketplace_offer_id='test_offer_2',
     provider_offer_id='141fadc1-6ae9-47e5-a74e-2dcf2b4dd554',
-    marketplace_date_created=now,
-    provider_id='2345',
     server_id='4567',
     start_time=now,
     end_time=now,
@@ -42,7 +40,9 @@ test_offer_2 = offer.Offer(
     server_config={'foo': 'bar'},
     cost=0.0,
     contract_id=None,
-    project_id='5599'
+    project_id='5599',
+    created_at=now,
+    updated_at=now,
 )
 
 
@@ -58,9 +58,9 @@ def test_get_offers(mock_get_all, client):
     response = client.get("/offer", follow_redirects=True)
     assert response.status_code == 200
     assert len(response.json) == 2
-    assert any(x['provider_id'] == test_offer_1.provider_id
+    assert any(x['project_id'] == test_offer_1.project_id
                for x in response.json)
-    assert any(x['provider_id'] == test_offer_2.provider_id
+    assert any(x['project_id'] == test_offer_2.project_id
                for x in response.json)
 
 

--- a/flocx_market/tests/unit/api/test_app_offer_contract_relationship.py
+++ b/flocx_market/tests/unit/api/test_app_offer_contract_relationship.py
@@ -9,7 +9,6 @@ CONF = flocx_market.conf.CONF
 now = datetime.datetime.utcnow()
 
 contract_1_bid = bid.Bid(marketplace_bid_id='test_bid_1',
-                         creator_bid_id="1234",
                          server_quantity=2,
                          start_time=now,
                          end_time=now,
@@ -17,11 +16,12 @@ contract_1_bid = bid.Bid(marketplace_bid_id='test_bid_1',
                          status="available",
                          server_config_query={'foo': 'bar'},
                          cost=11.5,
-                         project_id='5599'
+                         project_id='5599',
+                         created_at=now,
+                         updated_at=now,
                          )
 
 contract_2_bid = bid.Bid(marketplace_bid_id='test_bid_2',
-                         creator_bid_id="2345",
                          server_quantity=2,
                          start_time=now,
                          end_time=now,
@@ -29,12 +29,12 @@ contract_2_bid = bid.Bid(marketplace_bid_id='test_bid_2',
                          status="available",
                          server_config_query={'foo': 'bar'},
                          cost=11.5,
-                         project_id='5599'
+                         project_id='5599',
+                         created_at=now,
+                         updated_at=now,
                          )
 
-contract_1_offer = offer.Offer(marketplace_date_created=now,
-                               marketplace_offer_id='test_offer_1',
-                               provider_id='1234',
+contract_1_offer = offer.Offer(marketplace_offer_id='test_offer_1',
                                server_id='3456',
                                start_time=now,
                                end_time=now,
@@ -42,12 +42,12 @@ contract_1_offer = offer.Offer(marketplace_date_created=now,
                                server_config={'bar': 'foo'},
                                cost=0.0,
                                contract_id='test_contract_1',
-                               project_id='5599'
+                               project_id='5599',
+                               created_at=now,
+                               updated_at=now,
                                )
 
 contract_2_offer = offer.Offer(marketplace_offer_id='test_offer_2',
-                               marketplace_date_created=now,
-                               provider_id='2345',
                                server_id='4567',
                                start_time=now,
                                end_time=now,
@@ -55,8 +55,9 @@ contract_2_offer = offer.Offer(marketplace_offer_id='test_offer_2',
                                server_config={'foo': 'bar'},
                                cost=0.0,
                                contract_id='test_contract_2',
-                               project_id='5599'
-
+                               project_id='5599',
+                               created_at=now,
+                               updated_at=now,
                                )
 
 test_contract_1 = contract.Contract(contract_id='test_contract_1',
@@ -67,7 +68,9 @@ test_contract_1 = contract.Contract(contract_id='test_contract_1',
                                     cost=0.0,
                                     bid_id='test_bid_1',
                                     bid=None,
-                                    project_id='5599'
+                                    project_id='5599',
+                                    created_at=now,
+                                    updated_at=now,
                                     )
 
 test_contract_2 = contract.Contract(contract_id='test_contract_2',
@@ -78,7 +81,9 @@ test_contract_2 = contract.Contract(contract_id='test_contract_2',
                                     cost=0.0,
                                     bid_id='test_bid_2',
                                     bid=None,
-                                    project_id='5599'
+                                    project_id='5599',
+                                    created_at=now,
+                                    updated_at=now,
                                     )
 
 test_contract_dict = dict(contract_id='test_contract_2',
@@ -89,20 +94,28 @@ test_contract_dict = dict(contract_id='test_contract_2',
                           cost=0.0,
                           bid_id='test_bid_2',
                           offers=[contract_1_offer.marketplace_offer_id],
-                          project_id='5599'
+                          project_id='5599',
+                          created_at="2016-07-16T19:20:30",
+                          updated_at="2016-07-16T19:20:30",
                           )
 
 test_ocr_1 = ocr.OfferContractRelationship(
-                offer_contract_relationship_id='test_ocr_id_1',
-                marketplace_offer_id='test_offer_1',
-                contract_id='test_contract_1',
-                status='unretrieved')
+    offer_contract_relationship_id='test_ocr_id_1',
+    marketplace_offer_id='test_offer_1',
+    contract_id='test_contract_1',
+    status='unretrieved',
+    created_at=now,
+    updated_at=now,
+)
 
 test_ocr_2 = ocr.OfferContractRelationship(
-            offer_contract_relationship_id='test_ocr_id_2',
-            marketplace_offer_id='test_offer_2',
-            contract_id='test_contract_2',
-            status='unretrieved')
+    offer_contract_relationship_id='test_ocr_id_2',
+    marketplace_offer_id='test_offer_2',
+    contract_id='test_contract_2',
+    status='unretrieved',
+    created_at=now,
+    updated_at=now,
+)
 
 
 @mock.patch('flocx_market.objects.offer_contract_relationship'

--- a/flocx_market/tests/unit/db/sqlalchemy/test_api.py
+++ b/flocx_market/tests/unit/db/sqlalchemy/test_api.py
@@ -10,80 +10,68 @@ now = datetime.utcnow()
 
 test_offer_data = dict(
     provider_offer_id='a41fadc1-6ae9-47e5-a74e-2dcf2b4dd55a',
-    provider_id='2345',
-    marketplace_date_created=now,
     status='available',
+    project_id='1234',
     server_id='4567',
     start_time=now - timedelta(days=1),
     end_time=now + timedelta(days=1),
     server_config={'foo': 'bar'},
     cost=0.0,
-    # project_id='5599'
     )
 
 test_offer_data_2 = dict(
     provider_offer_id='141fadc1-6ae9-47e5-a74e-2dcf2b4dd554',
-    provider_id='2345',
-    marketplace_date_created=now,
     status='expired',
+    project_id='1234',
     server_id='456789',
     start_time=now - timedelta(days=2),
     end_time=now - timedelta(days=1),
     server_config={'foo': 'bar'},
     cost=0.0,
-    # project_id='5599'
     )
 
 
 test_offer_data_3 = dict(
     provider_offer_id='141fadc1-6ae9-47e5-a74e-2dcf2b455555',
-    provider_id='2345',
-    marketplace_date_created=now,
     status='available',
+    project_id='7788',
     server_id='123',
     start_time=now - timedelta(days=2),
     end_time=now - timedelta(days=1),
     server_config={'foo': 'bar'},
     cost=0.0,
-    # project_id='7788'
     )
 
 
-test_bid_data_1 = dict(creator_bid_id="12a59a51-b4d6-497d-9f75-f56c409305c8",
-                       server_quantity=2,
+test_bid_data_1 = dict(server_quantity=2,
                        start_time=now - timedelta(days=2),
                        end_time=now - timedelta(days=1),
                        duration=16400,
                        status="available",
                        server_config_query={'foo': 'bar'},
-                       # project_id='5599',
                        cost=11.5)
 
 
-test_bid_data_2 = dict(creator_bid_id="12a59a51-b4d6-497d-9f75-f56c409305c8",
-                       server_quantity=2,
+test_bid_data_2 = dict(server_quantity=2,
                        start_time=now - timedelta(days=2),
                        end_time=now + timedelta(days=1),
                        duration=16400,
                        status="available",
                        server_config_query={'foo': 'bar'},
-                       # project_id='5599',
                        cost=11.5)
 
-test_bid_data_3 = dict(creator_bid_id="12a59a51-b4d6-497d-9f75-f56c409305c8",
-                       server_quantity=2,
+test_bid_data_3 = dict(server_quantity=2,
                        start_time=now - timedelta(days=2),
                        end_time=now + timedelta(days=1),
                        duration=16400,
                        status="available",
                        server_config_query={'foo': 'bar'},
-                       # project_id='7788',
                        cost=11.5)
 
 admin_context = ctx.RequestContext(is_admin=True)
 
 scoped_context = ctx.RequestContext(is_admin=False,
-                                    project_id='5599')
+                                    project_id='1234')
 
 scoped_context_2 = ctx.RequestContext(is_admin=False,
                                       project_id='7788')
@@ -132,7 +120,7 @@ def test_offer_create(app, db, session):
 
 def test_offer_create_invalid_admin(app, db, session):
     data = dict(test_offer_data)
-    del data['provider_id']
+    del data['cost']
 
     with pytest.raises(DBError):
         api.offer_create(data, scoped_context)
@@ -232,7 +220,7 @@ def test_bid_create(app, db, session):
 
 def test_bid_create_invalid(app, db, session):
     data = dict(test_bid_data_1)
-    del data['creator_bid_id']
+    del data['cost']
 
     with pytest.raises(DBError):
         api.bid_create(data, scoped_context)

--- a/flocx_market/tests/unit/objects/test_object_bid.py
+++ b/flocx_market/tests/unit/objects/test_object_bid.py
@@ -6,27 +6,35 @@ from oslo_context import context as ctx
 now = datetime.datetime.utcnow()
 
 
-test_bid_1 = dict(marketplace_bid_id="123",
-                  creator_bid_id="1259a51-b4d6-497d-9f75-f56c409305c8",
-                  server_quantity=2,
-                  start_time=now,
-                  end_time=now,
-                  duration=16400,
-                  status="available",
-                  server_config_query={'foo': 'bar'},
-                  cost=11.2,
-                  project_id='5599')
+test_bid_1 = dict(
+    marketplace_bid_id="123",
+    creator_bid_id="1259a51-b4d6-497d-9f75-f56c409305c8",
+    server_quantity=2,
+    start_time=now,
+    end_time=now,
+    duration=16400,
+    status="available",
+    server_config_query={'foo': 'bar'},
+    cost=11.2,
+    project_id='5599',
+    created_at=now,
+    updated_at=now,
+)
 
-test_bid_2 = dict(marketplace_bid_id="1232",
-                  creator_bid_id="12a59a51-b4d6-497d-9f75-f56c409305c8",
-                  server_quantity=2,
-                  start_time=now,
-                  end_time=now,
-                  duration=16400,
-                  status="available",
-                  server_config_query={'foo': 'bar'},
-                  cost=11.5,
-                  project_id='5599')
+test_bid_2 = dict(
+    marketplace_bid_id="1232",
+    creator_bid_id="12a59a51-b4d6-497d-9f75-f56c409305c8",
+    server_quantity=2,
+    start_time=now,
+    end_time=now,
+    duration=16400,
+    status="available",
+    server_config_query={'foo': 'bar'},
+    cost=11.5,
+    project_id='5599',
+    created_at=now,
+    updated_at=now,
+)
 
 scoped_context = ctx.RequestContext(is_admin=False,
                                     project_id='5599')

--- a/flocx_market/tests/unit/objects/test_object_contract.py
+++ b/flocx_market/tests/unit/objects/test_object_contract.py
@@ -14,7 +14,9 @@ test_contract_dict_1 = dict(contract_id='test_contract_2',
                             cost=0.0,
                             bid_id='test_bid_2',
                             bid=None,
-                            offers=['test_offer_1']
+                            offers=['test_offer_1'],
+                            created_at=now,
+                            updated_at=now,
                             )
 
 test_contract_dict = dict(contract_id='test_contract_2',
@@ -26,7 +28,9 @@ test_contract_dict = dict(contract_id='test_contract_2',
                           bid_id='test_bid_2',
                           bid=None,
                           offers=['test_offer_1'],
-                          project_id='5599'
+                          project_id='5599',
+                          created_at=now,
+                          updated_at=now,
                           )
 
 scoped_context = ctx.RequestContext(is_admin=False,

--- a/flocx_market/tests/unit/objects/test_object_offer.py
+++ b/flocx_market/tests/unit/objects/test_object_offer.py
@@ -10,8 +10,6 @@ now = datetime.datetime.utcnow()
 test_offer_1 = dict(
     marketplace_offer_id='1234',
     provider_offer_id='a41fadc1-6ae9-47e5-a74e-2dcf2b4dd55a',
-    provider_id='2345',
-    marketplace_date_created=now,
     status='available',
     server_id='4567',
     start_time=now,
@@ -19,14 +17,14 @@ test_offer_1 = dict(
     server_config={'foo': 'bar'},
     cost=0.0,
     contract_id=None,
-    project_id=5599
+    project_id=5599,
+    created_at=now,
+    updated_at=now,
 )
 
 test_offer_2 = dict(
     marketplace_offer_id='124',
     provider_offer_id='141fadc1-6ae9-47e5-a74e-2dcf2b4dd554',
-    provider_id='2345',
-    marketplace_date_created=now,
     status='available',
     server_id='456789',
     start_time=now,
@@ -34,7 +32,9 @@ test_offer_2 = dict(
     server_config={'foo': 'bar'},
     cost=0.0,
     contract_id=None,
-    project_id=5599
+    project_id=5599,
+    created_at=now,
+    updated_at=now,
 )
 
 scoped_context = ctx.RequestContext(is_admin=False,

--- a/flocx_market/tests/unit/objects/test_object_offer_contract_relationship.py
+++ b/flocx_market/tests/unit/objects/test_object_offer_contract_relationship.py
@@ -1,12 +1,20 @@
+from datetime import datetime
+
 from flocx_market.objects import offer_contract_relationship as ocr
 import unittest.mock as mock
 from oslo_context import context as ctx
+
+now = datetime.utcnow()
+
 
 test_ocr_dict = dict(
     offer_contract_relationship_id='test_offer_contract_relationship_id',
     contract_id='test_contract_1',
     marketplace_offer_id='test_offer_1',
-    status='unretrieved')
+    status='unretrieved',
+    created_at=now,
+    updated_at=now,
+)
 
 scoped_context = ctx.RequestContext(is_admin=False,
                                     project_id='5599')


### PR DESCRIPTION
This change uses the TimestampMixin to standardize on created_at and updated_at
for all our objects; note that these columns are automatically set and updated
by oslo.db. It also removes creator-type columns, as those are superceded by
project_id

TG-183