### PR TITLE
Remove is_admin check from ocr update

### DIFF
--- a/flocx_market/db/sqlalchemy/api.py
+++ b/flocx_market/db/sqlalchemy/api.py
@@ -301,17 +301,14 @@ def offer_contract_relationship_create(context, values):
 def offer_contract_relationship_update(context,
                                        offer_contract_relationship_id,
                                        values):
-    if context.is_admin:
-        offer_contract_relationship_ref \
-            = offer_contract_relationship_get(context,
-                                              offer_contract_relationship_id)
-
-        values.pop('offer_contract_relationship_id', None)
-        offer_contract_relationship_ref.update(values)
-        offer_contract_relationship_ref.save(get_session())
-        return offer_contract_relationship_ref
-    else:
-        return None
+    offer_contract_relationship_ref \
+        = offer_contract_relationship_get(context,
+                                          offer_contract_relationship_id)
+    
+    values.pop('offer_contract_relationship_id', None)
+    offer_contract_relationship_ref.update(values)
+    offer_contract_relationship_ref.save(get_session())
+    return offer_contract_relationship_ref
 
 
 def offer_contract_relationship_destroy(context,

--- a/flocx_market/tests/unit/db/sqlalchemy/test_api.py
+++ b/flocx_market/tests/unit/db/sqlalchemy/test_api.py
@@ -499,29 +499,30 @@ def test_offer_contract_relationship_update_valid(app, db, session):
     assert check.marketplace_offer_id == offer_test_id
 
 
-def test_offer_contract_relationship_update_invalid_scoped(app, db, session):
-    contract_data, offer_test_id = create_test_contract_data_for_ocr()
-    contract = api.contract_create(contract_data, admin_context)
-    filters = {
-        'marketplace_offer_id': offer_test_id,
-        'contract_id': contract.contract_id
-    }
-    ocrs = api.offer_contract_relationship_get_all(
-        context=admin_context,
-        filters=filters,
-    )
-    ocr_id = ocrs[0].offer_contract_relationship_id
+# TODO(tzumainn): refactor once we re-enable ocr scoping for the update operation
+# def test_offer_contract_relationship_update_invalid_scoped(app, db, session):
+#     contract_data, offer_test_id = create_test_contract_data_for_ocr()
+#     contract = api.contract_create(contract_data, admin_context)
+#     filters = {
+#         'marketplace_offer_id': offer_test_id,
+#         'contract_id': contract.contract_id
+#     }
+#     ocrs = api.offer_contract_relationship_get_all(
+#         context=admin_context,
+#         filters=filters,
+#     )
+#     ocr_id = ocrs[0].offer_contract_relationship_id
 
-    api.offer_contract_relationship_update(
-        context=scoped_context,
-        offer_contract_relationship_id=ocr_id,
-        values=dict(status='testing'))
-    check = api.offer_contract_relationship_get(
-        context=admin_context,
-        offer_contract_relationship_id=ocr_id)
+#     api.offer_contract_relationship_update(
+#         context=scoped_context,
+#         offer_contract_relationship_id=ocr_id,
+#         values=dict(status='testing'))
+#     check = api.offer_contract_relationship_get(
+#         context=admin_context,
+#         offer_contract_relationship_id=ocr_id)
 
-    assert check.status != 'testing'
-    assert check.marketplace_offer_id == offer_test_id
+#     assert check.status != 'testing'
+#     assert check.marketplace_offer_id == offer_test_id
 
 
 def test_offer_contract_relationship_get_all_unexpired(app, db, session):


### PR DESCRIPTION
The provider needs to be able to update an ocr, but the is_admin
check prevents it from doing so.

Fixes #126