### PR TITLE
Removed time_created field when matcher creates a contract

### DIFF
--- a/flocx_market/matcher/match_engine.py
+++ b/flocx_market/matcher/match_engine.py
@@ -1,12 +1,10 @@
 from flocx_market.matcher import matcher
 from flocx_market.objects import bid
 from flocx_market.objects import contract
-import datetime
 
 
 def prepare_contract(offers_used, bid_, context):
     contract_data = dict(start_time=bid_.start_time,
-                         time_created=datetime.datetime.utcnow(),
                          end_time=bid_.end_time,
                          cost=bid_.cost,
                          project_id=bid_.project_id,


### PR DESCRIPTION
time_created is a field that was removed from the data model;
leaving it in results in an error.

Fixes #128