### PR TITLE
Remove the POST handler for the /contract endpoint

### DIFF
--- a/flocx_market/api/contract.py
+++ b/flocx_market/api/contract.py
@@ -17,12 +17,6 @@ class Contract(Resource):
             return c.to_dict()
 
     @classmethod
-    def post(cls):
-
-        data = request.get_json(force=True)
-        return contract.Contract.create(data, g.context).to_dict(), 201
-
-    @classmethod
     def delete(cls, contract_id):
 
         c = contract.Contract.get(contract_id, g.context)

--- a/flocx_market/tests/unit/api/test_app_contract.py
+++ b/flocx_market/tests/unit/api/test_app_contract.py
@@ -151,15 +151,6 @@ def test_delete_contract_missing(mock_get, client):
     assert response.status_code == 404
 
 
-@mock.patch('flocx_market.objects.contract.Contract.create')
-def test_create_contract(mock_create, client):
-    mock_create.return_value = test_contract_1
-    res = client.post('/contract', data=json.dumps(test_contract_dict))
-    assert res.status_code == 201
-    assert mock_create.call_count == 1
-    assert res.json == test_contract_1.to_dict()
-
-
 @mock.patch('flocx_market.objects.contract.Contract.save')
 @mock.patch('flocx_market.objects.contract.Contract.get')
 def test_update_contract(mock_get, mock_save, client):


### PR DESCRIPTION
We should not be able to create a contract via the REST API; this
should only happen as a result of the matching process.

Closes #125