### PR TITLE
Remove offer server_id unique constraint

### DIFF
--- a/flocx_market/db/sqlalchemy/api.py
+++ b/flocx_market/db/sqlalchemy/api.py
@@ -53,8 +53,15 @@ def offer_get_all_by_project_id(context):
         project_id=context.project_id).all()
 
 
-def offer_get_all_unexpired(context):
+def offer_get_all_by_server_id(context, server_id, status=None):
+    query = get_session().query(models.Offer).filter_by(
+        server_id=server_id)
+    if status is not None:
+        query = query.filter_by(status=status)
+    return query.all()
 
+
+def offer_get_all_unexpired(context):
     if context.is_admin:
         return get_session().query(models.Offer).filter(
             models.Offer.status != 'expired').all()
@@ -71,6 +78,12 @@ def offer_get_all_by_status(status, context):
 
 
 def offer_create(values, context):
+    server_id = values['server_id']
+    if len(offer_get_all_by_server_id(context, server_id, 'available')) > 0:
+        raise ValueError(
+            "Node %server_id already has an available offer",
+            server_id
+        )
 
     values['marketplace_offer_id'] = uuidutils.generate_uuid()
     offer_ref = models.Offer()

--- a/flocx_market/db/sqlalchemy/models.py
+++ b/flocx_market/db/sqlalchemy/models.py
@@ -63,7 +63,7 @@ class Offer(Base):
     )
     project_id = orm.Column(orm.String(64), nullable=False)
     status = orm.Column(orm.String(15), nullable=False, default="available")
-    server_id = orm.Column(orm.String(64), nullable=False, unique=True)
+    server_id = orm.Column(orm.String(64), nullable=False)
     start_time = orm.Column(orm.DateTime(timezone=True), nullable=False)
     end_time = orm.Column(orm.DateTime(timezone=True), nullable=True)
     server_config = orm.Column(

--- a/flocx_market/tests/unit/db/sqlalchemy/test_api.py
+++ b/flocx_market/tests/unit/db/sqlalchemy/test_api.py
@@ -92,6 +92,22 @@ def test_offer_get_all_by_project_id(app, db, session):
     assert len(api.offer_get_all_by_project_id(scoped_context)) == 2
 
 
+def test_offer_get_all_by_server_id(app, db, session):
+    api.offer_create(test_offer_data, scoped_context)
+    api.offer_create(test_offer_data_2, scoped_context)
+
+    assert len(api.offer_get_all_by_server_id(
+        scoped_context, test_offer_data["server_id"])) == 1
+
+
+def test_offer_get_all_by_server_id_and_status(app, db, session):
+    api.offer_create(test_offer_data, scoped_context)
+    api.offer_create(test_offer_data_2, scoped_context)
+
+    assert len(api.offer_get_all_by_server_id(
+        scoped_context, test_offer_data["server_id"], "expired")) == 0
+
+
 def test_offer_get_all_unexpired_admin(app, db, session):
     api.offer_create(test_offer_data, scoped_context)
     api.offer_create(test_offer_data_2, scoped_context)
@@ -115,6 +131,22 @@ def test_offer_create(app, db, session):
     check = api.offer_get(offer.marketplace_offer_id, scoped_context)
 
     assert check.to_dict() == offer.to_dict()
+
+
+def test_offer_create_duplicate_server_id_pass(app, db, session):
+    test_offer_data_expired = test_offer_data.copy()
+    expired_provider_offer_id = 'a41fadc1-6ae9-47e5-a74e-2dcf2b4dd55b'
+    test_offer_data_expired["status"] = "expired"
+    test_offer_data_expired["provider_offer_id"] = expired_provider_offer_id
+
+    api.offer_create(test_offer_data_expired, scoped_context)
+    api.offer_create(test_offer_data, scoped_context)
+
+
+def test_offer_create_duplicate_server_id_fail(app, db, session):
+    api.offer_create(test_offer_data, scoped_context)
+    with pytest.raises(ValueError):
+        api.offer_create(test_offer_data, scoped_context)
 
 
 def test_offer_create_invalid_no_cost_admin(app, db, session):


### PR DESCRIPTION
This PR removes the offer server_id unique constraint, and also
adds a check to ensure that a new offer for a server cannot be
created if there is an existing open offer for that server.

Fixes #50