### PR TITLE
Create matcher periodic job

### DIFF
--- a/flocx_market/conf/manager.py
+++ b/flocx_market/conf/manager.py
@@ -5,7 +5,12 @@ opts = [
     cfg.IntOpt('update_expire_frequency',
                default=60,
                help="The frequency in which the manager's \
-                     periodic task will run.\
+                     expiration periodic tasks will run.\
+                     Enter in seconds"),
+    cfg.IntOpt('matcher_frequency',
+               default=60,
+               help="The frequency in which the manager's \
+                     matcher periodic task will run.\
                      Enter in seconds")
 ]
 

--- a/flocx_market/db/sqlalchemy/api.py
+++ b/flocx_market/db/sqlalchemy/api.py
@@ -72,6 +72,9 @@ def offer_get_all_unexpired(context):
 
 
 def offer_get_all_by_status(status, context):
+    if context.is_admin:
+        return get_session().query(models.Offer)\
+                            .filter_by(status=status).all()
     return get_session().query(models.Offer)\
         .filter(models.Offer.status == status, models.Offer.project_id ==
                 context.project_id).all()
@@ -153,6 +156,9 @@ def bid_get_all_unexpired(context):
 
 
 def bid_get_all_by_status(status, context):
+    if context.is_admin:
+        return get_session().query(models.Bid)\
+                            .filter_by(status=status).all()
     return get_session().query(models.Bid)\
         .filter(models.Bid.status == status, models.Bid.project_id ==
                 context.project_id).all()

--- a/flocx_market/manager/service.py
+++ b/flocx_market/manager/service.py
@@ -5,6 +5,7 @@ from oslo_service import periodic_task
 from oslo_service import threadgroup
 import datetime
 
+from flocx_market.matcher import match_engine
 from flocx_market.objects.offer import Offer
 from flocx_market.objects.bid import Bid
 from flocx_market.objects.contract import Contract
@@ -80,3 +81,9 @@ class Manager(periodic_task.PeriodicTasks):
                 exp += 1
         if exp > 0:
             LOG.info("Updated " + str(exp) + " contracts")
+
+    @periodic_task.periodic_task(spacing=CONF.manager.matcher_frequency,
+                                 run_immediately=True)
+    def matcher(self, context):
+        LOG.info("Matching bids and offers")
+        match_engine.match(context)


### PR DESCRIPTION
This PR creates the matcher periodic job. It also adjusts some
'get_all'-type queries that filter on project_id, to not filter
on project_id if the context has 'is_admin=True'

Fixes #135