### PR TITLE
Use filters on *get_all_by* functions in dbapi

### DIFF
--- a/flocx_market/objects/bid.py
+++ b/flocx_market/objects/bid.py
@@ -58,12 +58,15 @@ class Bid(base.FLOCXMarketObject):
 
     @classmethod
     def get_all_by_project_id(cls, context):
-        by_project_id = db.bid_get_all_by_project_id(context)
+        by_project_id = \
+            db.bid_get_all_filters(context,
+                                   filters={'project_id': context.project_id})
         return cls._from_db_object_list(by_project_id)
 
     @classmethod
     def get_all_by_status(cls, status, context):
-        available = db.bid_get_all_by_status(status, context)
+        available = db.bid_get_all_filters(context,
+                                           filters={'status': status})
         return cls._from_db_object_list(available)
 
     def expire(self, context):

--- a/flocx_market/objects/offer.py
+++ b/flocx_market/objects/offer.py
@@ -59,7 +59,9 @@ class Offer(base.FLOCXMarketObject):
 
     @classmethod
     def get_all_by_project_id(cls, context):
-        by_project_id = db.offer_get_all_by_project_id(context)
+        by_project_id = db.offer_get_all_filters(context,
+                                                 filters={'project_id':
+                                                          context.project_id})
         return cls._from_db_object_list(by_project_id)
 
     def expire(self, context):
@@ -81,7 +83,9 @@ class Offer(base.FLOCXMarketObject):
                     return False
             return True
 
-        offers_by_status = db.offer_get_all_by_status('available', context)
+        offers_by_status = db.offer_get_all_filters(context,
+                                                    filters={'status':
+                                                             'available'})
 
         if start_time is None and end_time is None:
             return cls._from_db_object_list(offers_by_status)
@@ -105,5 +109,6 @@ class Offer(base.FLOCXMarketObject):
 
     @classmethod
     def get_all_by_status(cls, status, context):
-        available = db.offer_get_all_by_status(status, context)
+        available = db.offer_get_all_filters(context,
+                                             filters={'status': status})
         return cls._from_db_object_list(available)

--- a/flocx_market/tests/unit/db/sqlalchemy/test_api.py
+++ b/flocx_market/tests/unit/db/sqlalchemy/test_api.py
@@ -100,28 +100,31 @@ def test_offer_get_all_none_found(app, db, session):
     assert (len(api.offer_get_all(scoped_context)) == 0)
 
 
-def test_offer_get_all_by_project_id(app, db, session):
+def test_offer_get_all_filters(app, db, session):
+
+    assert len(api.offer_get_all_filters(admin_context)) == 0
+
     api.offer_create(test_offer_data, scoped_context)
     api.offer_create(test_offer_data_2, scoped_context)
     api.offer_create(test_offer_data_3, scoped_context_2)
 
-    assert len(api.offer_get_all_by_project_id(scoped_context)) == 2
+    assert len(api.offer_get_all_filters(admin_context)) == 3
 
+    assert len(api.offer_get_all_filters(admin_context,
+                                         filters={'project_id':
+                                                  scoped_context.project_id}
+                                         )) == 2
 
-def test_offer_get_all_by_server_id(app, db, session):
-    api.offer_create(test_offer_data, scoped_context)
-    api.offer_create(test_offer_data_2, scoped_context)
+    assert len(api.offer_get_all_filters(admin_context,
+                                         filters={'server_id':
+                                                  test_offer_data['server_id']}
+                                         )) == 1
 
-    assert len(api.offer_get_all_by_server_id(
-        scoped_context, test_offer_data["server_id"])) == 1
-
-
-def test_offer_get_all_by_server_id_and_status(app, db, session):
-    api.offer_create(test_offer_data, scoped_context)
-    api.offer_create(test_offer_data_2, scoped_context)
-
-    assert len(api.offer_get_all_by_server_id(
-        scoped_context, test_offer_data["server_id"], "expired")) == 0
+    assert len(api.offer_get_all_filters(admin_context,
+                                         filters={'server_id':
+                                                  test_offer_data['server_id'],
+                                                  'status': 'expired'}
+                                         )) == 0
 
 
 def test_offer_get_all_unexpired_admin(app, db, session):
@@ -250,11 +253,25 @@ def test_bid_get_all(app, db, session):
     assert len(api.bid_get_all(admin_context)) == 2
 
 
-def test_bid_get_all_by_project_id(app, db, session):
+def test_bid_get_all_filters(app, db, session):
+
+    assert len(api.bid_get_all_filters(admin_context)) == 0
+
     api.bid_create(test_bid_data_1, scoped_context)
     api.bid_create(test_bid_data_2, scoped_context)
+    api.bid_create(test_bid_data_3, scoped_context_2)
 
-    assert len(api.bid_get_all(admin_context)) == 2
+    assert len(api.bid_get_all_filters(admin_context)) == 3
+
+    assert len(api.bid_get_all_filters(admin_context,
+                                       filters={'project_id':
+                                                scoped_context.project_id}
+                                       )) == 2
+
+    assert len(api.bid_get_all_filters(admin_context,
+                                       filters={'project_id':
+                                                scoped_context.project_id,
+                                                'status': 'expired'})) == 0
 
 
 def test_bid_get_all_unexpired(app, db, session):

--- a/flocx_market/tests/unit/objects/test_object_bid.py
+++ b/flocx_market/tests/unit/objects/test_object_bid.py
@@ -66,7 +66,7 @@ def test_get_all(bid_get_all):
     bid_get_all.assert_called_once()
 
 
-@mock.patch('flocx_market.db.sqlalchemy.api.bid_get_all_by_project_id')
+@mock.patch('flocx_market.db.sqlalchemy.api.bid_get_all_filters')
 def test_get_all_by_project_id(bid_get_all):
     bid.Bid.get_all_by_project_id(scoped_context)
     bid_get_all.assert_called_once()

--- a/flocx_market/tests/unit/objects/test_object_offer.py
+++ b/flocx_market/tests/unit/objects/test_object_offer.py
@@ -67,7 +67,7 @@ def test_get_all(offer_get_all):
     offer_get_all.assert_called_once()
 
 
-@mock.patch('flocx_market.db.sqlalchemy.api.offer_get_all_by_project_id')
+@mock.patch('flocx_market.db.sqlalchemy.api.offer_get_all_filters')
 def test_get_all_by_project_id(offer_get_all):
     offer.Offer.get_all_by_project_id(scoped_context)
     offer_get_all.assert_called_once()


### PR DESCRIPTION
Updated the dbapi to use a filter for get_all_by, as opposed to 3
separate methods per object, such as offer_get_all_by_status,
get_all_by_server_id and get_all_by_project_id. Does not update the
business logic api, thereby preserving functionality. TG-143