### PR TITLE
Add oslo.policy checks

### DIFF
--- a/etc/flocx-market/flocx-market-policy-generator.conf
+++ b/etc/flocx-market/flocx-market-policy-generator.conf
@@ -1,0 +1,3 @@
+[DEFAULT]
+output_file = etc/flocx-market/policy.json.sample
+namespace = flocx-market

--- a/flocx_market/api/bid.py
+++ b/flocx_market/api/bid.py
@@ -1,25 +1,31 @@
 from flask_restful import Resource
 from flask import request, g
+import json
+
 from flocx_market.objects import bid
 from flocx_market.common import exception
-import json
+from flocx_market.common import policy
 
 
 class Bid(Resource):
 
     @classmethod
     def get(cls, bid_id=None):
+        cdict = g.context.to_policy_values()
 
         if bid_id is None:
+            policy.authorize('flocx_market:bid:get_all', cdict, cdict)
             return [x.to_dict() for x in bid.Bid.get_all(g.context)]
-
         try:
+            policy.authorize('flocx_market:bid:get', cdict, cdict)
             return bid.Bid.get(bid_id, g.context).to_dict()
         except exception.MarketplaceException as e:
             return json.dumps(e.message), e.code
 
     @classmethod
     def post(cls):
+        cdict = g.context.to_policy_values()
+        policy.authorize('flocx_market:bid:create', cdict, cdict)
 
         try:
             data = request.get_json(force=True)
@@ -29,6 +35,8 @@ class Bid(Resource):
 
     @classmethod
     def delete(cls, bid_id):
+        cdict = g.context.to_policy_values()
+        policy.authorize('flocx_market:bid:delete', cdict, cdict)
 
         try:
             b = bid.Bid.get(bid_id, g.context)
@@ -39,9 +47,10 @@ class Bid(Resource):
 
     @classmethod
     def put(cls, bid_id):
+        cdict = g.context.to_policy_values()
+        policy.authorize('flocx_market:bid:update', cdict, cdict)
 
         data = request.get_json(force=True)
-
         try:
             b = bid.Bid.get(bid_id, g.context)
             # we only allow status field to be modified

--- a/flocx_market/api/contract.py
+++ b/flocx_market/api/contract.py
@@ -1,25 +1,31 @@
 from flask_restful import Resource
 from flask import request, g
+import json
+
 from flocx_market.objects import contract
 from flocx_market.common import exception
-import json
+from flocx_market.common import policy
 
 
 class Contract(Resource):
 
     @classmethod
     def get(cls, contract_id=None):
+        cdict = g.context.to_policy_values()
 
         if contract_id is None:
+            policy.authorize('flocx_market:contract:get_all', cdict, cdict)
             return [x.to_dict() for x in contract.Contract.get_all(g.context)]
-
         try:
+            policy.authorize('flocx_market:contract:get', cdict, cdict)
             return contract.Contract.get(contract_id, g.context).to_dict()
         except exception.MarketplaceException as e:
             return json.dumps(e.message), e.code
 
     @classmethod
     def post(cls):
+        cdict = g.context.to_policy_values()
+        policy.authorize('flocx_market:contract:create', cdict, cdict)
 
         data = request.get_json(force=True)
         try:
@@ -29,6 +35,8 @@ class Contract(Resource):
 
     @classmethod
     def delete(cls, contract_id):
+        cdict = g.context.to_policy_values()
+        policy.authorize('flocx_market:contract:delete', cdict, cdict)
 
         try:
             c = contract.Contract.get(contract_id, g.context)
@@ -39,9 +47,10 @@ class Contract(Resource):
 
     @classmethod
     def put(cls, contract_id):
+        cdict = g.context.to_policy_values()
+        policy.authorize('flocx_market:contract:update', cdict, cdict)
 
         data = request.get_json(force=True)
-
         try:
             c = contract.Contract.get(contract_id, g.context)
             # we only allow status field to be modified

--- a/flocx_market/api/offer.py
+++ b/flocx_market/api/offer.py
@@ -1,25 +1,31 @@
 from flask_restful import Resource
 from flask import request, g
+import json
+
 from flocx_market.objects import offer
 from flocx_market.common import exception
-import json
+from flocx_market.common import policy
 
 
 class Offer(Resource):
 
     @classmethod
     def get(cls, offer_id=None):
+        cdict = g.context.to_policy_values()
 
         if offer_id is None:
+            policy.authorize('flocx_market:offer:get_all', cdict, cdict)
             return [x.to_dict() for x in offer.Offer.get_all(g.context)]
-
         try:
+            policy.authorize('flocx_market:offer:get', cdict, cdict)
             return offer.Offer.get(offer_id, g.context).to_dict()
         except exception.MarketplaceException as e:
             return json.dumps(e.message), e.code
 
     @classmethod
     def post(cls):
+        cdict = g.context.to_policy_values()
+        policy.authorize('flocx_market:offer:create', cdict, cdict)
 
         try:
             data = request.get_json(force=True)
@@ -29,6 +35,8 @@ class Offer(Resource):
 
     @classmethod
     def delete(cls, offer_id):
+        cdict = g.context.to_policy_values()
+        policy.authorize('flocx_market:offer:delete', cdict, cdict)
 
         try:
             o = offer.Offer.get(offer_id, g.context)
@@ -39,9 +47,10 @@ class Offer(Resource):
 
     @classmethod
     def put(cls, offer_id):
+        cdict = g.context.to_policy_values()
+        policy.authorize('flocx_market:offer:update', cdict, cdict)
 
         data = request.get_json(force=True)
-
         try:
             o = offer.Offer.get(offer_id, g.context)
             # we only allow status field to be modified

--- a/flocx_market/api/offer_contract_relationship.py
+++ b/flocx_market/api/offer_contract_relationship.py
@@ -1,22 +1,30 @@
 from flask_restful import Resource
 from flask import request, g
+import json
+
 from flocx_market.objects import offer_contract_relationship as ocr
 from flocx_market.common import exception
-
-import json
+from flocx_market.common import policy
 
 
 class OfferContractRelationship(Resource):
 
     @classmethod
     def get(cls, offer_contract_relationship_id=None):
+        cdict = g.context.to_policy_values()
 
         try:
             if offer_contract_relationship_id:
+                policy.authorize(
+                    'flocx_market:offer_contract_relationship:get',
+                    cdict, cdict)
                 ocr_with_id = ocr.OfferContractRelationship \
                     .get(g.context, offer_contract_relationship_id)
                 return ocr_with_id.to_dict()
 
+            policy.authorize(
+                'flocx_market:offer_contract_relationship:get_all',
+                cdict, cdict)
             offer_id = request.args.get('offer_id')
             contract_id = request.args.get('contract_id')
             status = request.args.get('status')
@@ -44,6 +52,9 @@ class OfferContractRelationship(Resource):
 
     @classmethod
     def delete(cls, offer_contract_relationship_id):
+        cdict = g.context.to_policy_values()
+        policy.authorize('flocx_market:offer_contract_relationship:delete',
+                         cdict, cdict)
 
         try:
             o = ocr.OfferContractRelationship.get(
@@ -57,8 +68,11 @@ class OfferContractRelationship(Resource):
 
     @classmethod
     def put(cls, offer_contract_relationship_id):
-        data = request.get_json(force=True)
+        cdict = g.context.to_policy_values()
+        policy.authorize('flocx_market:offer_contract_relationship:update',
+                         cdict, cdict)
 
+        data = request.get_json(force=True)
         try:
             o = ocr.OfferContractRelationship.get(
                                             g.context,

--- a/flocx_market/common/policy.py
+++ b/flocx_market/common/policy.py
@@ -1,0 +1,165 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import itertools
+
+from oslo_policy import policy
+
+import flocx_market.conf
+
+CONF = flocx_market.conf.CONF
+_ENFORCER = None
+
+default_policies = [
+    policy.RuleDefault('is_admin',
+                       'role:admin or role:flocx_market_admin',
+                       description='Full API access'),
+]
+
+bid_policies = [
+    policy.DocumentedRuleDefault(
+        'flocx_market:bid:create',
+        'rule:is_admin',
+        'Create bid',
+        [{'path': '/bid', 'method': 'POST'}]),
+    policy.DocumentedRuleDefault(
+        'flocx_market:bid:delete',
+        'rule:is_admin',
+        'Delete bid',
+        [{'path': '/bid/{bid_ident}', 'method': 'DELETE'}]),
+    policy.DocumentedRuleDefault(
+        'flocx_market:bid:get',
+        'rule:is_admin',
+        'Retrieve bid',
+        [{'path': '/bid/{bid_ident}', 'method': 'GET'}]),
+    policy.DocumentedRuleDefault(
+        'flocx_market:bid:get_all',
+        'rule:is_admin',
+        'Retrieve all bids',
+        [{'path': '/bid', 'method': 'GET'}]),
+    policy.DocumentedRuleDefault(
+        'flocx_market:bid:update',
+        'rule:is_admin',
+        'Update bid',
+        [{'path': '/bid', 'method': 'PUT'}]),
+]
+
+contract_policies = [
+    policy.DocumentedRuleDefault(
+        'flocx_market:contract:create',
+        'rule:is_admin',
+        'Create contract',
+        [{'path': '/contract', 'method': 'POST'}]),
+    policy.DocumentedRuleDefault(
+        'flocx_market:contract:delete',
+        'rule:is_admin',
+        'Delete contract',
+        [{'path': '/contract/{contract_ident}', 'method': 'DELETE'}]),
+    policy.DocumentedRuleDefault(
+        'flocx_market:contract:get',
+        'rule:is_admin',
+        'Retrieve contract',
+        [{'path': '/contract/{contract_ident}', 'method': 'GET'}]),
+    policy.DocumentedRuleDefault(
+        'flocx_market:contract:get_all',
+        'rule:is_admin',
+        'Retrieve all contracts',
+        [{'path': '/contract', 'method': 'GET'}]),
+    policy.DocumentedRuleDefault(
+        'flocx_market:contract:update',
+        'rule:is_admin',
+        'Update contract',
+        [{'path': '/contract', 'method': 'PUT'}]),
+]
+
+offer_policies = [
+    policy.DocumentedRuleDefault(
+        'flocx_market:offer:create',
+        'rule:is_admin',
+        'Create offer',
+        [{'path': '/offer', 'method': 'POST'}]),
+    policy.DocumentedRuleDefault(
+        'flocx_market:offer:delete',
+        'rule:is_admin',
+        'Delete offer',
+        [{'path': '/offer/{offer_ident}', 'method': 'DELETE'}]),
+    policy.DocumentedRuleDefault(
+        'flocx_market:offer:get',
+        'rule:is_admin',
+        'Retrieve offer',
+        [{'path': '/offer/{offer_ident}', 'method': 'GET'}]),
+    policy.DocumentedRuleDefault(
+        'flocx_market:offer:get_all',
+        'rule:is_admin',
+        'Retrieve all offers',
+        [{'path': '/offer', 'method': 'GET'}]),
+    policy.DocumentedRuleDefault(
+        'flocx_market:offer:update',
+        'rule:is_admin',
+        'Update offer',
+        [{'path': '/offer', 'method': 'PUT'}]),
+]
+
+ocr_policies = [
+    policy.DocumentedRuleDefault(
+        'flocx_market:offer_contract_relationship:delete',
+        'rule:is_admin',
+        'Delete offer_contract_relationship',
+        [{'path':
+          '/offer_contract_relationship/{offer_contract_relationship_ident}',
+          'method': 'DELETE'}]),
+    policy.DocumentedRuleDefault(
+        'flocx_market:offer_contract_relationship:get',
+        'rule:is_admin',
+        'Retrieve offer_contract_relationship',
+        [{'path':
+          '/offer_contract_relationship/{offer_contract_relationship_ident}',
+          'method': 'GET'}]),
+    policy.DocumentedRuleDefault(
+        'flocx_market:offer_contract_relationship:get_all',
+        'rule:is_admin',
+        'Retrieve all offer_contract_relationships',
+        [{'path': '/offer_contract_relationship', 'method': 'GET'}]),
+    policy.DocumentedRuleDefault(
+        'flocx_market:offer_contract_relationship:update',
+        'rule:is_admin',
+        'Update offer_contract_relationship',
+        [{'path': '/offer_contract_relationship', 'method': 'PUT'}]),
+]
+
+
+def list_rules():
+    policies = itertools.chain(
+        default_policies,
+        bid_policies,
+        contract_policies,
+        offer_policies,
+        ocr_policies,
+    )
+    return policies
+
+
+def get_enforcer():
+    CONF([], project='flocx-market')
+    global _ENFORCER
+    if not _ENFORCER:
+        _ENFORCER = policy.Enforcer(CONF)
+        _ENFORCER.register_defaults(list_rules())
+    return _ENFORCER
+
+
+def authorize(rule, target, creds, *args, **kwargs):
+    if not CONF.api.auth_enable:
+        return True
+
+    return get_enforcer().authorize(
+        rule, target, creds, do_raise=True, *args, **kwargs)

--- a/flocx_market/tests/unit/common/test_policy.py
+++ b/flocx_market/tests/unit/common/test_policy.py
@@ -1,0 +1,34 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from pytest import raises
+
+from oslo_policy import policy as oslo_policy
+
+from flocx_market.common import policy
+
+
+def test_authorized():
+    creds = {'roles': ['flocx_market_admin']}
+    assert(policy.authorize('flocx_market:offer:get', creds, creds))
+
+
+def test_unauthorized():
+    creds = {'roles': ['generic_user']}
+    with raises(oslo_policy.PolicyNotAuthorized):
+        policy.authorize('flocx_market:offer:get', creds, creds)
+
+
+def test_authorize_policy_not_registered():
+    creds = {'roles': ['generic_user']}
+    with raises(oslo_policy.PolicyNotRegistered):
+        policy.authorize('flocx_market:foo:bar', creds, creds)

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,13 @@ packages =
 [entry_points]
 oslo.config.opts =
     flocx-market.conf = flocx_market.conf.opts:list_opts
+
+oslo.policy.enforcer =
+    flocx-market = flocx_market.common.policy:get_enforcer
+
+oslo.policy.policies =
+    flocx-market = flocx_market.common.policy:list_rules
+
 console_scripts =
     flocx-market-api = flocx_market.cmd.api:main
     flocx-market-dbsync = flocx_market.cmd.dbsync:main

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,12 @@ basepython = python3
 commands =
     oslo-config-generator --config-file etc/flocx-market/flocx-market-config-generator.conf
 
+[testenv:genpolicy]
+basepython = python3
+sitepackages = False
+commands =
+    oslopolicy-sample-generator --config-file etc/flocx-market/flocx-market-policy-generator.conf
+
 [testenv:commit]
 basepython = python3
 commands = 


### PR DESCRIPTION
This PR adds oslo.policy checks, enabling alternative usages where
a single admin has administrative rights over all nodes.

Addresses #150